### PR TITLE
Bump criticalup/criticalup-dev to 1.0.0-prerelease.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup"
-version = "0.1.0"
+version = "1.0.0-prerelease.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-dev"
-version = "0.1.0"
+version = "1.0.0-prerelease.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",

--- a/crates/criticalup-dev/Cargo.toml
+++ b/crates/criticalup-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criticalup-dev"
-version = "0.1.0"
+version = "1.0.0-prerelease.1"
 edition = "2021"
 publish = false
 

--- a/crates/criticalup/Cargo.toml
+++ b/crates/criticalup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criticalup"
-version = "0.1.0"
+version = "1.0.0-prerelease.1"
 edition = "2021"
 authors = ["The CriticalUp Developers"]
 description = "Ferrocene toolchain manager"


### PR DESCRIPTION
We're preparing for a 1.0, so what about a 1.0 prerelease to try things out?

I'll tag a release after.