### PR TITLE
Add revocation support for hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "criticaltrust",
  "serde",
  "serde_json",
+ "time",
  "tiny_http",
 ]
 

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -86,6 +86,8 @@ pub enum KeyRole {
     Packages,
     /// `redirects` key role, used to sign dynamic server redirects.
     Redirects,
+    /// `revocation` key role, used to sign revoked content hashes.
+    Revocation,
     /// `root` key role, used to sign other keys.
     Root,
     #[serde(other)]

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -7,6 +7,7 @@ use crate::keys::{KeyRole, PublicKey};
 use crate::signatures::{Signable, SignedPayload};
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 /// Typed representation of a manifest version number.
 ///
@@ -154,12 +155,26 @@ pub struct PackageFile {
     pub needs_proxy: bool,
 }
 
+// Revocations
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RevocationInfo {
+    pub revoked_content_sha256: Vec<String>,
+    pub expires_at: OffsetDateTime,
+}
+
+impl Signable for RevocationInfo {
+    const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
+}
+
 // Keys
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KeysManifest {
     pub version: ManifestVersion<1>,
     pub keys: Vec<SignedPayload<PublicKey>>,
+    pub revoked_signatures: SignedPayload<RevocationInfo>,
 }
 
 #[cfg(test)]

--- a/crates/mock-download-server/Cargo.toml
+++ b/crates/mock-download-server/Cargo.toml
@@ -12,3 +12,4 @@ criticaltrust = { path = "../criticaltrust" }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 tiny_http = { version = "0.12.0", default-features = false, features = ["rustls"] }
+time = { version = "0.3.7", features = ["std", "serde", "serde-well-known"] }

--- a/crates/mock-download-server/src/handlers.rs
+++ b/crates/mock-download-server/src/handlers.rs
@@ -3,7 +3,9 @@
 
 use crate::Serialize;
 use crate::{AuthenticationToken, Data};
-use criticaltrust::manifests::ManifestVersion;
+use criticaltrust::manifests::{ManifestVersion, RevocationInfo};
+use criticaltrust::signatures::SignedPayload;
+use time::{Duration, OffsetDateTime};
 use tiny_http::{Header, Method, Request, Response, ResponseBox, StatusCode};
 
 pub(crate) fn handle_request(data: &Data, req: &Request) -> ResponseBox {
@@ -39,6 +41,11 @@ fn handle_v1_keys(data: &Data) -> Result<Resp, Resp> {
     Ok(Resp::json(&criticaltrust::manifests::KeysManifest {
         version: ManifestVersion,
         keys: data.keys.clone(),
+        revoked_signatures: SignedPayload::new(&RevocationInfo {
+            revoked_content_sha256: Vec::new(),
+            expires_at: OffsetDateTime::now_utc() + Duration::days(99),
+        })
+        .unwrap(),
     }))
 }
 

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -6,11 +6,12 @@ mod server;
 
 pub use crate::server::MockServer;
 use criticaltrust::keys::PublicKey;
-use criticaltrust::manifests::ReleaseManifest;
+use criticaltrust::manifests::{ReleaseManifest, RevocationInfo};
 use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use time::{Duration, OffsetDateTime};
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -23,6 +24,7 @@ pub struct AuthenticationToken {
 pub struct Data {
     pub tokens: HashMap<String, AuthenticationToken>,
     pub keys: Vec<SignedPayload<PublicKey>>,
+    pub revoked_signatures: SignedPayload<RevocationInfo>,
     pub release_manifests: HashMap<(String, String), ReleaseManifest>,
 }
 
@@ -31,6 +33,11 @@ pub fn new() -> Builder {
         data: Data {
             tokens: HashMap::new(),
             keys: Vec::new(),
+            revoked_signatures: SignedPayload::new(&RevocationInfo {
+                revoked_content_sha256: Vec::new(),
+                expires_at: OffsetDateTime::now_utc() + Duration::days(99),
+            })
+            .unwrap(),
             release_manifests: HashMap::new(),
         },
     }


### PR DESCRIPTION
Adds support for Revocation Keys.

- Introduces new key role type (new variant).
- Introduces a field to get the said keys.
- Introduces changes in mock/test code to support those keys.

 
Ticket: https://ferroussystems.clickup.com/t/86947z6fp