### PR TITLE
Paths are not strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "base64",
  "elliptic-curve",
  "itertools",
+ "once_cell",
  "p256",
  "rand_core",
  "serde",

--- a/crates/criticaltrust/Cargo.toml
+++ b/crates/criticaltrust/Cargo.toml
@@ -22,6 +22,7 @@ aws-config = { version = "1.0.0", optional = true, features = ["rustls", "behavi
 aws-sdk-kms = { version = "1.3.0", optional = true, features = ["rustls"] }
 aws-smithy-runtime-api = { version = "1.0.0", optional = true }
 tokio = { version = "1.29.1", features = ["rt", "rt-multi-thread"], optional = true }
+once_cell = "1.19.0"
 
 [dev-dependencies]
 itertools = "0.10.3"

--- a/crates/criticaltrust/src/integrity/mod.rs
+++ b/crates/criticaltrust/src/integrity/mod.rs
@@ -6,6 +6,8 @@
 mod detect_manifest;
 mod verifier;
 
+use std::path::PathBuf;
+
 pub use verifier::{IntegrityVerifier, VerifiedPackage};
 
 /// Integrity error detected by [`IntegrityVerifier`].
@@ -13,38 +15,38 @@ pub use verifier::{IntegrityVerifier, VerifiedPackage};
 pub enum IntegrityError {
     #[error("failed to deserialize the package manifest at {path}")]
     PackageManifestDeserialization {
-        path: String,
+        path: PathBuf,
         #[source]
         inner: serde_json::Error,
     },
     #[error("failed to verify the package manifest at {path}")]
     PackageManifestVerification {
-        path: String,
+        path: PathBuf,
         #[source]
         inner: crate::Error,
     },
     #[error("wrong POSIX permissions for {path} (expected: {expected:o}, found {found:o})")]
     WrongPosixPermissions {
-        path: String,
+        path: PathBuf,
         expected: u32,
         found: u32,
     },
     #[error("wrong checksum for {path}")]
-    WrongChecksum { path: String },
+    WrongChecksum { path: PathBuf },
     #[error("the product name of {path} is not {expected} (the file path is wrong)")]
-    WrongProductName { path: String, expected: String },
+    WrongProductName { path: PathBuf, expected: String },
     #[error("the package name of {path} is not {expected} (the file path is wrong)")]
-    WrongPackageName { path: String, expected: String },
+    WrongPackageName { path: PathBuf, expected: String },
     #[error("no package manifest found")]
     NoPackageManifestFound,
     #[error("expected file {path} is not present")]
-    MissingFile { path: String },
+    MissingFile { path: PathBuf },
     #[error("unexpected file {path} is present")]
-    UnexpectedFile { path: String },
+    UnexpectedFile { path: PathBuf },
     #[error("unexpected file {path} in prefix managed by CriticalUp ({prefix})")]
-    UnexpectedFileInManagedPrefix { path: String, prefix: String },
+    UnexpectedFileInManagedPrefix { path: PathBuf, prefix: PathBuf },
     #[error("file {path} is referenced by multiple package manifests")]
-    FileReferencedByMultipleManifests { path: String },
+    FileReferencedByMultipleManifests { path: PathBuf },
     #[error("file {path} was loaded multiple times")]
-    FileLoadedMultipleTimes { path: String },
+    FileLoadedMultipleTimes { path: PathBuf },
 }

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -401,8 +401,8 @@ mod tests {
                     .file(&BIN_B)
                     .file(&SHARE_A),
             )
-            .file(&BIN_A.mode(0o644))
-            .file(&BIN_B.mode(0o644))
+            .file(&BIN_A.clone().mode(0o644))
+            .file(&BIN_B.clone().mode(0o644))
             .file(&SHARE_A)
             .assert_errors(errors![
                 IntegrityError::WrongPosixPermissions {
@@ -423,14 +423,14 @@ mod tests {
     fn test_files_with_both_wrong_mode_and_wrong_checksum() {
         IntegrityTest::new()
             .manifest(ManifestBuilder::new("a", "b").file(&BIN_A).file(&BIN_B))
-            .file(&BIN_A.add_content(b"!").mode(0o644))
+            .file(&BIN_A.clone().add_content(b"!").mode(0o644))
             .file(&BIN_B)
             .assert_errors(errors![
                 IntegrityError::WrongPosixPermissions {
                     path,
                     expected: 0o755,
                     found: 0o644,
-                } if path == "bin/a",
+                } if path == Path::new("bin/a"),
                 IntegrityError::WrongChecksum { path } if path == Path::new("bin/a"),
             ]);
     }

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -76,7 +76,7 @@ impl<'a> IntegrityVerifier<'a> {
         }
 
         if let Some(found) = is_package_manifest(&path_str) {
-            if let Err(err) = self.add_package_manifest(&path, &found, contents) {
+            if let Err(err) = self.add_package_manifest(path, &found, contents) {
                 self.errors.push(err);
             }
         } else {
@@ -103,9 +103,7 @@ impl<'a> IntegrityVerifier<'a> {
         }
 
         for path in self.referenced_by_manifests_but_missing.into_keys() {
-            self.errors.push(IntegrityError::MissingFile {
-                path: path,
-            });
+            self.errors.push(IntegrityError::MissingFile { path });
         }
 
         for path in self.added_but_not_referenced_by_manifests.into_keys() {
@@ -114,16 +112,14 @@ impl<'a> IntegrityVerifier<'a> {
                     if path.starts_with(prefix) {
                         self.errors
                             .push(IntegrityError::UnexpectedFileInManagedPrefix {
-                                path: path,
+                                path,
                                 prefix: prefix.clone(),
                             });
                         break;
                     }
                 }
             } else {
-                self.errors.push(IntegrityError::UnexpectedFile {
-                    path: path,
-                });
+                self.errors.push(IntegrityError::UnexpectedFile { path });
             }
         }
 
@@ -174,10 +170,10 @@ impl<'a> IntegrityVerifier<'a> {
             if file.needs_proxy {
                 let proxy_name = file_path
                     .file_name()
-                    .map(|v| PathBuf::from(v))
+                    .map(PathBuf::from)
                     .unwrap_or(file_path.clone());
 
-                proxies_paths.insert(proxy_name.into(), file_path.clone());
+                proxies_paths.insert(proxy_name, file_path.clone());
             }
 
             if let Some(found) = self
@@ -251,9 +247,9 @@ mod tests {
     use crate::test_utils::TestEnvironment;
     use crate::Error;
     use itertools::Itertools;
+    use once_cell::sync::Lazy;
     use std::borrow::Cow;
     use std::ffi::OsStr;
-    use once_cell::sync::Lazy;
 
     // Note that the tests verify all possible permutations of input files, ensuring the expected
     // behavior regardless of the order files are provided to the verifier.

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -254,10 +254,10 @@ mod tests {
     // Note that the tests verify all possible permutations of input files, ensuring the expected
     // behavior regardless of the order files are provided to the verifier.
 
-    const BIN_A: Lazy<TestFile> = Lazy::new(|| TestFile::new("bin/a", 0o755, b"foo binary"));
-    const BIN_B: Lazy<TestFile> = Lazy::new(|| TestFile::new("bin/b", 0o755, b"bar binary"));
-    const SHARE_A: Lazy<TestFile> = Lazy::new(|| TestFile::new("share/a", 0o644, b"a file"));
-    const SHARE_B: Lazy<TestFile> = Lazy::new(|| TestFile::new("share/b", 0o644, b"b file"));
+    static BIN_A: Lazy<TestFile> = Lazy::new(|| TestFile::new("bin/a", 0o755, b"foo binary"));
+    static BIN_B: Lazy<TestFile> = Lazy::new(|| TestFile::new("bin/b", 0o755, b"bar binary"));
+    static SHARE_A: Lazy<TestFile> = Lazy::new(|| TestFile::new("share/a", 0o644, b"a file"));
+    static SHARE_B: Lazy<TestFile> = Lazy::new(|| TestFile::new("share/b", 0o644, b"b file"));
 
     macro_rules! btreemap {
         ($($key:expr => $value:expr),*$(,)?) => {{
@@ -409,12 +409,12 @@ mod tests {
                     path,
                     expected: 0o755,
                     found: 0o644,
-                } if path == "bin/a",
+                } if path == Path::new("bin/a"),
                 IntegrityError::WrongPosixPermissions {
                     path,
                     expected: 0o755,
                     found: 0o644,
-                } if path == "bin/b",
+                } if path == Path::new("bin/b"),
             ]);
     }
 
@@ -431,7 +431,7 @@ mod tests {
                     expected: 0o755,
                     found: 0o644,
                 } if path == "bin/a",
-                IntegrityError::WrongChecksum { path } if path == "bin/a",
+                IntegrityError::WrongChecksum { path } if path == Path::new("bin/a"),
             ]);
     }
 
@@ -811,7 +811,7 @@ mod tests {
 
         fn manifest(self, builder: ManifestBuilder) -> Self {
             self.manifest_in(
-                builder.prefix.join(&format!(
+                builder.prefix.join(format!(
                     "share/criticaltrust/{}/{}.json",
                     builder.manifest.product, builder.manifest.package
                 )),

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -3,6 +3,8 @@
 
 //! Serializable and deserializable representation of criticaltrust manifests.
 
+use std::path::PathBuf;
+
 use crate::keys::{KeyRole, PublicKey};
 use crate::signatures::{Signable, SignedPayload};
 use serde::de::Error as _;
@@ -148,7 +150,7 @@ impl Signable for Package {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct PackageFile {
-    pub path: String,
+    pub path: PathBuf,
     pub posix_mode: u32,
     #[serde(with = "crate::serde_base64")]
     pub sha256: Vec<u8>,

--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -31,7 +31,7 @@ pub(crate) fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
         .map(|p| p.installation_id())
         .filter_map(|id| {
             state
-                .resolve_binary_proxy(&id, &PathBuf::from(&binary_name))
+                .resolve_binary_proxy(&id, PathBuf::from(&binary_name))
                 .map(|p| (id, p))
         })
         .next()

--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -31,7 +31,7 @@ pub(crate) fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
         .map(|p| p.installation_id())
         .filter_map(|id| {
             state
-                .resolve_binary_proxy(&id, &binary_name)
+                .resolve_binary_proxy(&id, &PathBuf::from(&binary_name))
                 .map(|p| (id, p))
         })
         .next()

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -6,7 +6,7 @@
 //! binary inside of the chosen criticalup installation.
 
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::errors::BinaryProxyUpdateError;
@@ -39,14 +39,7 @@ pub fn update(
             for entry in iter {
                 let entry = entry.map_err(list_dir_error)?;
 
-                let entry_name = match entry.file_name().to_str().map(|s| s.to_string()) {
-                    Some(name) => name,
-                    None => {
-                        // No binary proxy will have a non-UTF-8 name.
-                        remove_unexpected(&entry.path())?;
-                        continue;
-                    }
-                };
+                let entry_name = PathBuf::from(entry.file_name());
 
                 if expected_proxies.remove(&*entry_name) {
                     ensure_link(proxy_binary, &entry.path())?;
@@ -166,6 +159,7 @@ fn remove_unexpected(path: &Path) -> Result<(), BinaryProxyUpdateError> {
 mod tests {
     use std::collections::BTreeMap;
     use std::io::Write;
+    use std::path::PathBuf;
 
     use tempfile::{tempdir, NamedTempFile};
 
@@ -257,7 +251,7 @@ mod tests {
         fn verified_packages(proxies: &[&str]) -> Vec<VerifiedPackage> {
             let mut proxies_paths = BTreeMap::new();
             for proxy in proxies {
-                proxies_paths.insert(proxy.to_string(), Path::new("bin").join(proxy));
+                proxies_paths.insert(PathBuf::from(proxy), Path::new("bin").join(proxy));
             }
 
             vec![VerifiedPackage {


### PR DESCRIPTION

Gets rid of the idea that `path: String` and replaces it with `path: PathBuf`.