### PR TITLE
Repair criticalup run in Windows

### DIFF
--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -12,6 +12,13 @@ use std::process::{Command, Stdio};
 
 pub(crate) fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
     let binary_name = arg0(&whitelabel)?;
+    let mut binary_path = PathBuf::from(&binary_name);
+    // On Windows, we assume executables will *always* have `.exe`
+    // `cargo.exe` does not invoke `rustc.exe` though, it invokes
+    // `rustc`
+    #[cfg(windows)]
+    binary_path.set_extension("exe");
+
     let args: Vec<_> = std::env::args_os().skip(1).collect();
 
     let config = Config::detect(whitelabel)?;
@@ -31,7 +38,7 @@ pub(crate) fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
         .map(|p| p.installation_id())
         .filter_map(|id| {
             state
-                .resolve_binary_proxy(&id, PathBuf::from(&binary_name))
+                .resolve_binary_proxy(&id, &binary_path)
                 .map(|p| (id, p))
         })
         .next()

--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -12,12 +12,19 @@ use std::process::{Command, Stdio};
 
 pub(crate) fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
     let binary_name = arg0(&whitelabel)?;
-    let mut binary_path = PathBuf::from(&binary_name);
-    // On Windows, we assume executables will *always* have `.exe`
-    // `cargo.exe` does not invoke `rustc.exe` though, it invokes
-    // `rustc`
+    
+    #[cfg(not(windows))]
+    let binary_path = PathBuf::from(&binary_name);
     #[cfg(windows)]
-    binary_path.set_extension("exe");
+    let binary_path = {
+        let mut binary_path = PathBuf::from(&binary_name);
+        // On Windows, we assume executables will *always* have `.exe`
+        // `cargo.exe` does not invoke `rustc.exe` though, it invokes
+        // `rustc`
+        #[cfg(windows)]
+        binary_path.set_extension("exe");
+        binary_path
+    };
 
     let args: Vec<_> = std::env::args_os().skip(1).collect();
 

--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -12,7 +12,7 @@ use std::process::{Command, Stdio};
 
 pub(crate) fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
     let binary_name = arg0(&whitelabel)?;
-    
+
     #[cfg(not(windows))]
     let binary_path = PathBuf::from(&binary_name);
     #[cfg(windows)]

--- a/crates/criticalup-cli/tests/cli/binary_proxies.rs
+++ b/crates/criticalup-cli/tests/cli/binary_proxies.rs
@@ -4,7 +4,7 @@
 use crate::assert_output;
 use crate::utils::TestEnvironment;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use tempfile::tempdir;
 
@@ -51,6 +51,11 @@ fn invoking_inside_of_installed_project() {
     )
     .unwrap();
 
+    #[cfg(not(windows))]
+    let executable_name = "sample";
+    #[cfg(windows)]
+    let executable_name = "sample.exe";
+
     // Create a sample state file referencing the binary proxy.
     std::fs::write(
         test_env.root().join("state.json"),
@@ -60,7 +65,7 @@ fn invoking_inside_of_installed_project() {
                 INSTALLATION_ID: {
                     "manifests": ["/path/to/manifest/a", "/path/to/manifest/b"],
                     "binary_proxies": {
-                        "sample": "bin/sample",
+                        executable_name: PathBuf::from("bin").join(executable_name),
                     },
                 },
             },
@@ -77,7 +82,7 @@ fn invoking_inside_of_installed_project() {
             .join("toolchains")
             .join(INSTALLATION_ID)
             .join("bin")
-            .join("sample"),
+            .join(executable_name),
         r#"fn main() { println!("proxies work!"); }"#,
     );
 


### PR DESCRIPTION
`cargo run` does not invoke `rustc.exe`, it invokes `rustc`. 😅 