### PR TITLE
No Packages: better error message

### DIFF
--- a/crates/criticalup-cli/tests/cli/install.rs
+++ b/crates/criticalup-cli/tests/cli/install.rs
@@ -13,6 +13,16 @@ fn help_message() {
 }
 
 #[test]
+fn empty_packages_list() {
+    let test_env = TestEnvironment::prepare();
+    let mut current_dir = std::env::current_dir().unwrap();
+    current_dir.push("tests/resources/criticalup-empty-packages.toml");
+    let manifest_path = current_dir.to_str().unwrap();
+
+    assert_output!(test_env.cmd().args(["install", "--project", manifest_path]));
+}
+
+#[test]
 fn already_installed_toolchain_should_not_throw_error() {
     let test_env = TestEnvironment::prepare();
 

--- a/crates/criticalup-cli/tests/cli/utils.rs
+++ b/crates/criticalup-cli/tests/cli/utils.rs
@@ -195,6 +195,11 @@ macro_rules! assert_output {
             "caused by: No such file or directory (os error 2)",
         );
 
+        settings.add_filter(
+            r"error: failed to load the project manifest at.*criticalup-empty-packages.toml",
+            "error: failed to load the project manifest at /path/to/manifest/criticalup-empty-packages.toml",
+        );
+
         #[cfg(windows)]
         settings.add_filter("exit code: ", "exit status: ");
         #[cfg(windows)]

--- a/crates/criticalup-cli/tests/resources/criticalup-empty-packages.toml
+++ b/crates/criticalup-cli/tests/resources/criticalup-empty-packages.toml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: The Ferrocene Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+# Manifest for test
+manifest-version = 1
+
+[products.ferrocene]
+release = "nightly-2024-02-28"
+packages = []

--- a/crates/criticalup-cli/tests/snapshots/cli__install__empty_packages_list.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__install__empty_packages_list.snap
@@ -1,0 +1,13 @@
+---
+source: crates/criticalup-cli/tests/cli/install.rs
+expression: repr
+---
+exit: exit status: 1
+
+empty stdout
+
+stderr
+------
+error: failed to load the project manifest at /path/to/manifest/criticalup-empty-packages.toml 
+  caused by: the 'packages' list for product 'ferrocene' in your project manifest is empty. please provide at least one package in the 'packages' list.
+------

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -133,6 +133,10 @@ pub enum ProjectManifestLoadingError {
     )]
     ManifestVersionTooBig { user_version: u32 },
 
+    #[error("the 'packages' list for product '{}' in your project manifest is empty. \
+    please provide at least one package in the 'packages' list.", .product_name)]
+    MissingPackagesInManifestProduct { product_name: String },
+
     #[error("unknown substitution variable: ${{{0}}}")]
     UnknownVariableInSubstitution(String),
     #[error("unterminated substitution")]

--- a/crates/criticalup-core/src/project_manifest/mod.rs
+++ b/crates/criticalup-core/src/project_manifest/mod.rs
@@ -264,10 +264,23 @@ fn load_inner(path: &Path) -> Result<ProjectManifest, ProjectManifestLoadingErro
 
     products.sort_by(|a, b| a.name.cmp(&b.name));
 
+    // We do not support more than one product at this time. This check has to be removed
+    // when we start supporting multiple products.
     if products.len() > 1 {
         return Err(MultipleProductsNotSupportedInProjectManifest(
             products.len(),
         ));
+    }
+
+    // We must fail if the project manifest contains empty packages list for any product.
+    for product in &products {
+        if product.packages.len() == 0 {
+            return Err(
+                ProjectManifestLoadingError::MissingPackagesInManifestProduct {
+                    product_name: product.name.to_string(),
+                },
+            );
+        }
     }
 
     Ok(ProjectManifest { products })


### PR DESCRIPTION
Improves error messages for when `packages` list in the manifest is empty.

## Testing instructions

### Create `criticalup.toml` with content

```toml
manifest-version = 1

[products.ferrocene]
release = "nightly-2024-04-02"
packages = []
```

### Run

```
cargo run -p criticalup -- install --project criticalup.toml
```

You should see an error 

```
error: failed to load the project manifest at criticalup.toml
  caused by: the 'packages' list for product 'ferrocene' in your project manifest is empty. please provide at least one package in the 'packages' list.
```


Ticket: https://ferroussystems.clickup.com/t/8694fp4z8