### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.2] - 2024-07-11
+
 ### Added
 
 - Retry downloads in case of network issue (#28).
@@ -32,6 +34,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/ferrocene/criticalup/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ferrocene/criticalup/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/ferrocene/criticalup/compare/v1.0.0...v1.0.0-prerelease.1


### PR DESCRIPTION
This is an update to the CHANGELOG. Once this is merged, we cut a tag from `main`.