### PR TITLE
Implement the `--reinstall` flag

### DIFF
--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -17,7 +17,11 @@ use crate::Context;
 
 pub const DEFAULT_RELEASE_ARTIFACT_FORMAT: ReleaseArtifactFormat = ReleaseArtifactFormat::TarXz;
 
-pub(crate) async fn run(ctx: &Context, project: Option<PathBuf>) -> Result<(), Error> {
+pub(crate) async fn run(
+    ctx: &Context,
+    reinstall: bool,
+    project: Option<PathBuf>,
+) -> Result<(), Error> {
     // TODO: If `std::io::stdout().is_terminal() == true``, provide a nice, fancy progress bar using indicatif.
     //       Retain existing behavior to support non-TTY usage.
 
@@ -41,7 +45,7 @@ pub(crate) async fn run(ctx: &Context, project: Option<PathBuf>) -> Result<(), E
             let does_this_installation_exist_in_state = state
                 .installations()
                 .contains_key(&product.installation_id());
-            if !does_this_installation_exist_in_state {
+            if !does_this_installation_exist_in_state || reinstall {
                 // If the installation directory exists, but the State has no installation of that
                 // InstallationId, then re-run the install command and go through installation.
                 install_product_afresh(ctx, &state, &manifest_path, product).await?;
@@ -51,7 +55,7 @@ pub(crate) async fn run(ctx: &Context, project: Option<PathBuf>) -> Result<(), E
                 // reflect this manifest/project.
                 state.update_installation_manifests(&product.installation_id(), &manifest_path)?;
                 println!("Skipping installation for product '{}' because it seems to be already installed.\n\
-                    If you want to reinstall it, please run 'criticalup remove' followed by 'criticalup install' command.",
+                    If you want to reinstall it, please run 'criticalup install --reinstall'.",
                          product.name());
             }
         }

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -126,7 +126,7 @@ enum Commands {
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,
-        /// Force installation of products that have already been installed
+        /// Reinstall products that may have already been installed
         #[arg(long)]
         reinstall: bool,
     },

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -50,7 +50,9 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
             Some(AuthCommands::Remove) => commands::auth_remove::run(&ctx).await?,
             None => commands::auth::run(&ctx).await?,
         },
-        Commands::Install { project } => commands::install::run(&ctx, project).await?,
+        Commands::Install { project, reinstall } => {
+            commands::install::run(&ctx, reinstall, project).await?
+        }
         Commands::Clean => commands::clean::run(&ctx).await?,
         Commands::Remove { project } => commands::remove::run(&ctx, project).await?,
         Commands::Run { command, project } => commands::run::run(&ctx, command, project).await?,
@@ -124,6 +126,9 @@ enum Commands {
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,
+        /// Force installation of products that have already been installed
+        #[arg(long)]
+        reinstall: bool,
     },
 
     /// Delete all unused and untracked installations

--- a/crates/criticalup-cli/tests/snapshots/cli__install__already_installed_toolchain_should_not_throw_error.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__install__already_installed_toolchain_should_not_throw_error.snap
@@ -7,7 +7,7 @@ exit: exit status: 0
 stdout
 ------
 Skipping installation for product 'ferrocene' because it seems to be already installed.
-If you want to reinstall it, please run 'criticalup remove' followed by 'criticalup install' command.
+If you want to reinstall it, please run 'criticalup install --reinstall'.
 ------
 
 empty stderr

--- a/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
@@ -15,5 +15,6 @@ Usage:
 
 Options:
       --project <PROJECT>  Path to the manifest `criticalup.toml`
+      --reinstall          Force installation of products that have already been installed
   -h, --help               Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
@@ -15,6 +15,6 @@ Usage:
 
 Options:
       --project <PROJECT>  Path to the manifest `criticalup.toml`
-      --reinstall          Force installation of products that have already been installed
+      --reinstall          Reinstall products that may have already been installed
   -h, --help               Print help
 ------


### PR DESCRIPTION
This PR implements the `--reinstall` flag for the `install` command. Right now it only forces the installation of already existing components.
