### PR TITLE
Revocation Checks

### DIFF
--- a/crates/criticaltrust/Cargo.toml
+++ b/crates/criticaltrust/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 sha2 = "0.10.8"
 thiserror = "1.0.61"
-time = { version = "0.3.36", features = ["std", "serde", "serde-well-known"] }
+time = { version = "0.3.36", features = ["std", "serde", "serde-well-known", "macros"] }
 aws-config = { version = "1.5.0", optional = true, features = ["rustls", "behavior-version-latest"] }
 aws-sdk-kms = { version = "1.28.0", optional = true, features = ["rustls"] }
 aws-smithy-runtime-api = { version = "1.6.1", optional = true }

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error(transparent)]
+    FromUtf8(#[from] FromUtf8Error),
     #[error("failed to sign data")]
     SignatureFailed,
     #[error("failed to verify signed data")]

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::keys::KeyRole;
+use std::string::FromUtf8Error;
 use thiserror::Error;
 
 #[non_exhaustive]
@@ -23,6 +24,12 @@ pub enum Error {
     InvalidKey(String),
     #[error("unsupported key")]
     UnsupportedKey,
+    #[error("verification failed because the signatures expired")]
+    SignaturesExpired,
+    #[error("failed to verify signed data because payload is revoked")]
+    ContentRevoked,
+    #[error("failed to calculate SHA256 from payload")]
+    PayloadSha256CalcFailed(#[source] FromUtf8Error),
     #[cfg(feature = "aws-kms")]
     #[error("failed to retrieve the public key from AWS KMS")]
     AwsKmsFailedToGetPublicKey(

--- a/crates/criticaltrust/src/integrity/mod.rs
+++ b/crates/criticaltrust/src/integrity/mod.rs
@@ -49,4 +49,6 @@ pub enum IntegrityError {
     FileReferencedByMultipleManifests { path: PathBuf },
     #[error("file {path} was loaded multiple times")]
     FileLoadedMultipleTimes { path: PathBuf },
+    #[error("revocation information is missing which is required to verify")]
+    MissingRevocationInfo,
 }

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -136,13 +136,17 @@ impl<'a> IntegrityVerifier<'a> {
         found: &FoundPackageManifest,
         contents: &[u8],
     ) -> Result<(), IntegrityError> {
+        let revocation_info = self
+            .keychain
+            .revocation_info()
+            .ok_or_else(|| IntegrityError::MissingRevocationInfo)?;
         let manifest = serde_json::from_slice::<PackageManifest>(contents)
             .map_err(|e| IntegrityError::PackageManifestDeserialization {
                 path: path.into(),
                 inner: e,
             })?
             .signed
-            .into_verified(self.keychain, self.keychain.revocation_info())
+            .into_verified(self.keychain, &revocation_info)
             .map_err(|e| IntegrityError::PackageManifestVerification {
                 path: path.into(),
                 inner: e,

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -142,7 +142,7 @@ impl<'a> IntegrityVerifier<'a> {
                 inner: e,
             })?
             .signed
-            .into_verified(self.keychain)
+            .into_verified(self.keychain, self.keychain.revocation_info())
             .map_err(|e| IntegrityError::PackageManifestVerification {
                 path: path.into(),
                 inner: e,

--- a/crates/criticaltrust/src/keys/pair_aws_kms.rs
+++ b/crates/criticaltrust/src/keys/pair_aws_kms.rs
@@ -116,7 +116,7 @@ mod tests {
     fn test_roundtrip() {
         let localstack = Localstack::init();
         let key = localstack.create_key(KeySpec::EccNistP256);
-        let signed_revocation_info = RevocationInfo::new(datetime!(2025-01-01 0:00 UTC));
+        let signed_revocation_info = RevocationInfo::new(vec![], datetime!(2025-01-01 0:00 UTC));
 
         let keypair = AwsKmsKeyPair::new(
             &key,

--- a/crates/criticaltrust/src/keys/pair_aws_kms.rs
+++ b/crates/criticaltrust/src/keys/pair_aws_kms.rs
@@ -100,13 +100,13 @@ impl KeyPair for AwsKmsKeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::revocation_info::RevocationInfo;
     use aws_sdk_kms::config::Credentials;
     use aws_sdk_kms::types::KeyUsageType;
     use rand_core::{OsRng, RngCore};
     use std::process::Command;
     use std::sync::Once;
     use tokio::runtime::Runtime;
-
     // We want to have tests for all of criticaltrust, which makes testing the integration with AWS
     // KMS quite tricky. To make it work, the tests for this module spawn a Docker container for
     // "localstack", a local replica of AWS services meant for testing.
@@ -115,6 +115,7 @@ mod tests {
     fn test_roundtrip() {
         let localstack = Localstack::init();
         let key = localstack.create_key(KeySpec::EccNistP256);
+        let signed_revocation_info = RevocationInfo::new();
 
         let keypair = AwsKmsKeyPair::new(
             &key,
@@ -128,7 +129,7 @@ mod tests {
         let signature = keypair.sign(&payload).expect("failed to sign");
         keypair
             .public()
-            .verify(KeyRole::Root, &payload, &signature)
+            .verify(KeyRole::Root, &payload, &signature, &signed_revocation_info)
             .expect("failed to verify");
     }
 

--- a/crates/criticaltrust/src/keys/pair_aws_kms.rs
+++ b/crates/criticaltrust/src/keys/pair_aws_kms.rs
@@ -106,6 +106,7 @@ mod tests {
     use rand_core::{OsRng, RngCore};
     use std::process::Command;
     use std::sync::Once;
+    use time::macros::datetime;
     use tokio::runtime::Runtime;
     // We want to have tests for all of criticaltrust, which makes testing the integration with AWS
     // KMS quite tricky. To make it work, the tests for this module spawn a Docker container for
@@ -115,7 +116,7 @@ mod tests {
     fn test_roundtrip() {
         let localstack = Localstack::init();
         let key = localstack.create_key(KeySpec::EccNistP256);
-        let signed_revocation_info = RevocationInfo::new();
+        let signed_revocation_info = RevocationInfo::new(datetime!(2025-01-01 0:00 UTC));
 
         let keypair = AwsKmsKeyPair::new(
             &key,

--- a/crates/criticaltrust/src/keys/pair_ephemeral.rs
+++ b/crates/criticaltrust/src/keys/pair_ephemeral.rs
@@ -5,6 +5,7 @@ use crate::keys::newtypes::{PayloadBytes, PrivateKeyBytes, SignatureBytes};
 use crate::keys::{KeyAlgorithm, KeyId, KeyPair, KeyRole, PublicKey};
 use crate::signatures::PublicKeysRepository;
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 /// Pair of public and private keys generated at runtime and kept in memory.
@@ -12,6 +13,7 @@ use time::OffsetDateTime;
 /// There is intentionally no way to persist the private key of ephemeral key pairs, as that's
 /// considerably less secure than storing the key in a Hardware Security Module. Ephemeral key
 /// pairs are primarily meant to be used during automated testing.
+#[derive(Serialize, Deserialize)]
 pub struct EphemeralKeyPair {
     public: PublicKey,
     private: PrivateKeyBytes<'static>,

--- a/crates/criticaltrust/src/keys/pair_ephemeral.rs
+++ b/crates/criticaltrust/src/keys/pair_ephemeral.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 /// There is intentionally no way to persist the private key of ephemeral key pairs, as that's
 /// considerably less secure than storing the key in a Hardware Security Module. Ephemeral key
 /// pairs are primarily meant to be used during automated testing.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct EphemeralKeyPair {
     public: PublicKey,
     private: PrivateKeyBytes<'static>,

--- a/crates/criticaltrust/src/keys/pair_ephemeral.rs
+++ b/crates/criticaltrust/src/keys/pair_ephemeral.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::keys::newtypes::{PayloadBytes, PrivateKeyBytes, SignatureBytes};
-use crate::keys::{KeyAlgorithm, KeyPair, KeyRole, PublicKey};
+use crate::keys::{KeyAlgorithm, KeyId, KeyPair, KeyRole, PublicKey};
+use crate::signatures::PublicKeysRepository;
 use crate::Error;
 use time::OffsetDateTime;
 
@@ -14,6 +15,12 @@ use time::OffsetDateTime;
 pub struct EphemeralKeyPair {
     public: PublicKey,
     private: PrivateKeyBytes<'static>,
+}
+
+impl PublicKeysRepository for EphemeralKeyPair {
+    fn get<'a>(&'a self, _id: &KeyId) -> Option<&'a PublicKey> {
+        Some(&self.public)
+    }
 }
 
 impl EphemeralKeyPair {

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -44,8 +44,14 @@ impl PublicKey {
             return Err(Error::SignaturesExpired);
         }
 
-        let hashed_payload =
-            String::from_utf8_lossy(hash_sha256(payload.as_bytes()).as_slice()).to_string();
+        let hashed_sha = hash_sha256(payload.as_bytes());
+        let mut hashed_payload = String::new();
+        for byte in hashed_sha {
+            // The bytes returned by Sha256 (in hashed_sha) are to be read as hex and are not to be
+            // confused with UTF-8 strings.
+            hashed_payload.push_str(&format!("{byte:X}"));
+        }
+
         if revocation_info
             .revoked_content_sha256
             .contains(&hashed_payload)

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -7,7 +7,7 @@ use crate::keys::KeyAlgorithm;
 use crate::revocation_info::RevocationInfo;
 use crate::sha256::hash_sha256;
 use crate::signatures::{PublicKeysRepository, Signable};
-use crate::Error;
+use crate::{Error, NoRevocationsCheck};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -99,6 +99,8 @@ impl PublicKey {
         self.role != KeyRole::Unknown && self.algorithm != KeyAlgorithm::Unknown
     }
 }
+
+impl NoRevocationsCheck for PublicKey {}
 
 impl PublicKeysRepository for PublicKey {
     fn get<'a>(&'a self, id: &KeyId) -> Option<&'a PublicKey> {

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -47,7 +47,7 @@ impl PublicKey {
         let hashed_payload = hash_sha256(payload.as_bytes());
         if revocation_info
             .revoked_content_sha256
-            .contains(&hashed_payload.into())
+            .contains(&hashed_payload)
         {
             return Err(Error::ContentRevoked);
         }

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -27,6 +27,7 @@ impl PublicKey {
     /// revoked content does not match the payload.
     ///
     /// Signature verification could fail if:
+    /// * The Expiration date has passed.
     /// * The signature is present in the `RevocationInfo`.
     /// * The `RevocationInfo` cannot be verified.
     /// * [`verify_payload`](PublicKey::verify_without_revocations) fails.
@@ -49,12 +50,8 @@ impl PublicKey {
             return Err(Error::SignaturesExpired);
         }
 
-        let sha256_payload = match String::from_utf8(hash_sha256(payload.as_bytes())) {
-            Ok(sha) => sha,
-            Err(err) => return Err(Error::PayloadSha256CalcFailed(err)),
-        };
-
-        if revocation_info.revoked_content_sha256.contains(&sha256_payload) {
+        let s = String::from_utf8_lossy(hash_sha256(payload.as_bytes()).as_slice()).to_string();
+        if revocation_info.revoked_content_sha256.contains(&s) {
             return Err(Error::ContentRevoked);
         }
         self.verify_no_revocations_check(role, payload, signature)?;

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -44,17 +44,10 @@ impl PublicKey {
             return Err(Error::SignaturesExpired);
         }
 
-        let hashed_sha = hash_sha256(payload.as_bytes());
-        let mut hashed_payload = String::new();
-        for byte in hashed_sha {
-            // The bytes returned by Sha256 (in hashed_sha) are to be read as hex and are not to be
-            // confused with UTF-8 strings.
-            hashed_payload.push_str(&format!("{byte:X}"));
-        }
-
+        let hashed_payload = hash_sha256(payload.as_bytes());
         if revocation_info
             .revoked_content_sha256
-            .contains(&hashed_payload)
+            .contains(&hashed_payload.into())
         {
             return Err(Error::ContentRevoked);
         }

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+extern crate core;
+
 pub mod errors;
 pub mod integrity;
 pub mod keys;

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -15,3 +15,6 @@ pub mod signatures;
 mod test_utils;
 
 pub use errors::Error;
+
+/// Trait to make sure that verification of only certain types does not check for revocation.
+pub trait NoRevocationCheck {}

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -11,10 +11,11 @@ mod serde_base64;
 mod sha256;
 pub mod signatures;
 
+pub mod revocation_info;
 #[cfg(test)]
 mod test_utils;
 
 pub use errors::Error;
 
 /// Trait to make sure that verification of only certain types does not check for revocation.
-pub trait NoRevocationCheck {}
+pub trait NoRevocationsCheck {}

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::keys::{KeyRole, PublicKey};
 use crate::signatures::{Signable, SignedPayload};
+use crate::NoRevocationCheck;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -159,6 +160,7 @@ pub struct PackageFile {
 
 // Revocations
 
+/// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RevocationInfo {
@@ -169,6 +171,11 @@ pub struct RevocationInfo {
 impl Signable for RevocationInfo {
     const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
 }
+
+/// Make sure verification of `RevocationInfo` type does no checks for revocations.
+///
+/// If we did, then this would be a circular logic and we say No! to such logic.
+impl NoRevocationCheck for RevocationInfo {}
 
 // Keys
 

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -6,11 +6,10 @@
 use std::path::PathBuf;
 
 use crate::keys::{KeyRole, PublicKey};
+use crate::revocation_info::RevocationInfo;
 use crate::signatures::{Signable, SignedPayload};
-use crate::NoRevocationCheck;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 
 /// Typed representation of a manifest version number.
 ///
@@ -157,25 +156,6 @@ pub struct PackageFile {
     pub sha256: Vec<u8>,
     pub needs_proxy: bool,
 }
-
-// Revocations
-
-/// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct RevocationInfo {
-    pub revoked_content_sha256: Vec<String>,
-    pub expires_at: OffsetDateTime,
-}
-
-impl Signable for RevocationInfo {
-    const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
-}
-
-/// Make sure verification of `RevocationInfo` type does no checks for revocations.
-///
-/// If we did, then this would be a circular logic and we say No! to such logic.
-impl NoRevocationCheck for RevocationInfo {}
 
 // Keys
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -10,6 +10,7 @@ use time::OffsetDateTime;
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
+    // Incoming SHA256 data from the API is in the form of String, but we save each as a `Vec<u8>`.
     pub revoked_content_sha256: Vec<Vec<u8>>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -10,25 +10,13 @@ use time::OffsetDateTime;
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
-    pub revoked_content_sha256: Vec<RevocationContentSha256>,
+    pub revoked_content_sha256: Vec<Vec<u8>>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct RevocationContentSha256(#[serde(with = "crate::serde_base64")] Vec<u8>);
-
-impl From<Vec<u8>> for RevocationContentSha256 {
-    fn from(revoked_content_sha256: Vec<u8>) -> Self {
-        RevocationContentSha256(revoked_content_sha256)
-    }
-}
-
 impl RevocationInfo {
-    pub fn new(
-        revoked_content_sha256: Vec<RevocationContentSha256>,
-        expires_at: OffsetDateTime,
-    ) -> Self {
+    pub fn new(revoked_content_sha256: Vec<Vec<u8>>, expires_at: OffsetDateTime) -> Self {
         RevocationInfo {
             revoked_content_sha256,
             expires_at,
@@ -44,3 +32,15 @@ impl Signable for RevocationInfo {
 ///
 /// If we did, then this would be a circular logic and we say No! to such logic.
 impl NoRevocationsCheck for RevocationInfo {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    #[test]
+    fn debug_revocation_info() {
+        let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2025-08-05 00:00 UTC));
+        assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2025-08-05 0:00:00.0 +00:00:00 }", format!("{:?}", r));
+    }
+}

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -8,15 +8,22 @@ use time::OffsetDateTime;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
     pub revoked_content_sha256: Vec<String>,
+    #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
 }
 
-impl Default for RevocationInfo {
-    fn default() -> Self {
+impl RevocationInfo {
+    pub fn new() -> Self {
         RevocationInfo {
             revoked_content_sha256: Vec::new(),
             expires_at: OffsetDateTime::now_utc(),
         }
+    }
+}
+
+impl Default for RevocationInfo {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -5,7 +5,6 @@ use crate::keys::KeyRole;
 use crate::signatures::Signable;
 use crate::NoRevocationsCheck;
 use serde::{Deserialize, Serialize};
-use time::macros::datetime;
 use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
@@ -31,17 +30,17 @@ impl From<Vec<u8>> for RevocationContentSha256 {
 }
 
 impl RevocationInfo {
-    pub fn new() -> Self {
+    pub fn new(datetime: OffsetDateTime) -> Self {
         RevocationInfo {
             revoked_content_sha256: Vec::new(),
-            expires_at: datetime!(2025-01-01 0:00 UTC),
+            expires_at: datetime,
         }
     }
 }
 
 impl Default for RevocationInfo {
     fn default() -> Self {
-        Self::new()
+        Self::new(OffsetDateTime::now_utc())
     }
 }
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -1,0 +1,31 @@
+use crate::keys::KeyRole;
+use crate::signatures::Signable;
+use crate::NoRevocationsCheck;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+/// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RevocationInfo {
+    pub revoked_content_sha256: Vec<String>,
+    pub expires_at: OffsetDateTime,
+}
+
+impl Default for RevocationInfo {
+    fn default() -> Self {
+        RevocationInfo {
+            revoked_content_sha256: Vec::new(),
+            expires_at: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+impl Signable for RevocationInfo {
+    const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
+}
+
+/// Make sure verification of `RevocationInfo` type does no checks for revocations.
+///
+/// If we did, then this would be a circular logic and we say No! to such logic.
+impl NoRevocationsCheck for RevocationInfo {}

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -11,9 +11,23 @@ use time::OffsetDateTime;
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
-    pub revoked_content_sha256: Vec<String>,
+    pub revoked_content_sha256: Vec<RevocationContentSha256>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RevocationContentSha256 {
+    #[serde(with = "crate::serde_base64")]
+    pub revoked_content_sha256: Vec<u8>,
+}
+
+impl From<Vec<u8>> for RevocationContentSha256 {
+    fn from(revoked_content_sha256: Vec<u8>) -> Self {
+        RevocationContentSha256 {
+            revoked_content_sha256,
+        }
+    }
 }
 
 impl RevocationInfo {

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::keys::KeyRole;
 use crate::signatures::Signable;
 use crate::NoRevocationsCheck;

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -6,7 +6,6 @@ use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
 pub struct RevocationInfo {
     pub revoked_content_sha256: Vec<String>,
     pub expires_at: OffsetDateTime,

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn new_revocation_info() {
-        let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2025-08-05 00:00 UTC));
-        assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2025-08-05 0:00:00.0 +00:00:00 }", format!("{:?}", r));
+        let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2400-10-10 00:00 UTC));
+        assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2400-10-10 0:00:00.0 +00:00:00 }", format!("{:?}", r));
     }
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -16,16 +16,11 @@ pub struct RevocationInfo {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct RevocationContentSha256 {
-    #[serde(with = "crate::serde_base64")]
-    pub revoked_content_sha256: Vec<u8>,
-}
+pub struct RevocationContentSha256(#[serde(with = "crate::serde_base64")] Vec<u8>);
 
 impl From<Vec<u8>> for RevocationContentSha256 {
     fn from(revoked_content_sha256: Vec<u8>) -> Self {
-        RevocationContentSha256 {
-            revoked_content_sha256,
-        }
+        RevocationContentSha256(revoked_content_sha256)
     }
 }
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -25,10 +25,13 @@ impl From<Vec<u8>> for RevocationContentSha256 {
 }
 
 impl RevocationInfo {
-    pub fn new(datetime: OffsetDateTime) -> Self {
+    pub fn new(
+        revoked_content_sha256: Vec<RevocationContentSha256>,
+        expires_at: OffsetDateTime,
+    ) -> Self {
         RevocationInfo {
-            revoked_content_sha256: Vec::new(),
-            expires_at: datetime,
+            revoked_content_sha256,
+            expires_at,
         }
     }
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -2,6 +2,7 @@ use crate::keys::KeyRole;
 use crate::signatures::Signable;
 use crate::NoRevocationsCheck;
 use serde::{Deserialize, Serialize};
+use time::macros::datetime;
 use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
@@ -16,7 +17,7 @@ impl RevocationInfo {
     pub fn new() -> Self {
         RevocationInfo {
             revoked_content_sha256: Vec::new(),
-            expires_at: OffsetDateTime::now_utc(),
+            expires_at: datetime!(2025-01-01 0:00 UTC),
         }
     }
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -38,12 +38,6 @@ impl RevocationInfo {
     }
 }
 
-impl Default for RevocationInfo {
-    fn default() -> Self {
-        Self::new(OffsetDateTime::now_utc())
-    }
-}
-
 impl Signable for RevocationInfo {
     const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -40,7 +40,7 @@ mod tests {
     use time::macros::datetime;
 
     #[test]
-    fn debug_revocation_info() {
+    fn new_revocation_info() {
         let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2025-08-05 00:00 UTC));
         assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2025-08-05 0:00:00.0 +00:00:00 }", format!("{:?}", r));
     }

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -3,7 +3,7 @@
 
 use crate::keys::{KeyId, KeyRole, PublicKey};
 use crate::manifests::KeysManifest;
-use crate::revocation_info::RevocationInfo;
+use crate::revocation_info::{RevocationContentSha256, RevocationInfo};
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
 use std::collections::HashMap;
@@ -24,7 +24,10 @@ impl Keychain {
     pub fn new(trust_root: &PublicKey) -> Result<Self, Error> {
         let mut keychain = Self {
             keys: HashMap::new(),
-            revocation_info: RevocationInfo::new(datetime!(2025-01-01 0:00 UTC)),
+            revocation_info: RevocationInfo::new(
+                Vec::<RevocationContentSha256>::new(),
+                datetime!(2025-01-01 0:00 UTC),
+            ),
         };
 
         if trust_root.role != KeyRole::Root {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -7,6 +7,7 @@ use crate::revocation_info::RevocationInfo;
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
 use std::collections::HashMap;
+use time::macros::datetime;
 
 /// Collection of all trusted public keys.
 pub struct Keychain {
@@ -23,7 +24,7 @@ impl Keychain {
     pub fn new(trust_root: &PublicKey) -> Result<Self, Error> {
         let mut keychain = Self {
             keys: HashMap::new(),
-            revocation_info: RevocationInfo::new(),
+            revocation_info: RevocationInfo::new(datetime!(2025-01-01 0:00 UTC)),
         };
 
         if trust_root.role != KeyRole::Root {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -23,7 +23,7 @@ impl Keychain {
     pub fn new(trust_root: &PublicKey) -> Result<Self, Error> {
         let mut keychain = Self {
             keys: HashMap::new(),
-            revocation_info: RevocationInfo::default(),
+            revocation_info: RevocationInfo::new(),
         };
 
         if trust_root.role != KeyRole::Root {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -46,6 +46,9 @@ impl Keychain {
         &self.revocation_info
     }
 
+    /// Load the following into [`Keychain`] provided the [`KeysManifest`].
+    /// 1. All the verified keys.
+    /// 2. Revocation information from the revoked content.
     pub fn load_all(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
         // Load all keys from KeysManifest.
         for key in &keys_manifest.keys {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -45,14 +45,15 @@ impl Keychain {
     pub fn load_all(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
         // Load all keys from KeysManifest.
         for key in &keys_manifest.keys {
-            let a = self.load(key)?;
+            let _ = self.load(key)?;
         }
 
         // Special case: verify and load only RevocationInfo.
         let revocation_info = keys_manifest
             .revoked_signatures
-            .get_verified_no_revocations_check(self)?.clone();
-        self.revocation_info = revocation_info;
+            .get_verified_no_revocations_check(self)?;
+        self.revocation_info = revocation_info.clone();
+
         Ok(())
     }
 

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -5,6 +5,7 @@ use crate::keys::{KeyId, KeyRole, PublicKey};
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
 use std::collections::HashMap;
+use crate::manifests::{KeysManifest, RevocationInfo};
 
 /// Collection of all trusted public keys.
 pub struct Keychain {
@@ -38,6 +39,14 @@ impl Keychain {
         let key = key.get_verified(self)?;
         self.load_inner(&key)
     }
+
+    // TODO change the name here from `lock_and_load` to something else.
+    pub fn load_with_revocation_check(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
+        let _ =
+
+        Ok(())
+    }
+
 
     fn load_inner(&mut self, key: &PublicKey) -> Result<KeyId, Error> {
         if !key.is_supported() {

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -3,10 +3,10 @@
 
 use crate::keys::newtypes::{PayloadBytes, SignatureBytes};
 use crate::keys::{KeyId, KeyPair, KeyRole, PublicKey};
+use crate::revocation_info::RevocationInfo;
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use std::cell::{Ref, RefCell};
-use crate::manifests::RevocationInfo;
 
 /// Piece of data with signatures attached to it.
 ///
@@ -43,7 +43,7 @@ impl<T: Signable> SignedPayload<T> {
         })
     }
 
-    /// Add a new signature to this signed paylaod, generated using the provided [`KeyPair`].
+    /// Add a new signature to this signed payload, generated using the provided [`KeyPair`].
     pub fn add_signature(&mut self, keypair: &dyn KeyPair) -> Result<(), Error> {
         self.signatures.push(Signature {
             key_sha256: keypair.public().calculate_id(),
@@ -58,33 +58,44 @@ impl<T: Signable> SignedPayload<T> {
     /// As signature verification and deserialization is expensive, it is only performed the first
     /// time the method is called. The cached results from the initial call will be returned in the
     /// rest of the cases.
-    // pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
-    //     let borrow = self.verified_deserialized.borrow();
-    //
-    //     if borrow.is_none() {
-    //         let value = verify_signature(
-    //             keys,
-    //             &self.signatures,
-    //             PayloadBytes::borrowed(self.signed.as_bytes()),
-    //         )?;
-    //
-    //         // In theory, `borrow_mut()` could panic if an immutable borrow was alive at the same
-    //         // time. In practice that won't happen, as we only populate the cache before returning
-    //         // any reference to the cached data.
-    //         drop(borrow);
-    //         *self.verified_deserialized.borrow_mut() = Some(value);
-    //     }
-    //
-    //     Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
-    //         b.as_ref().unwrap()
-    //     }))
-    // }
-
-    pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
+    pub fn get_verified(
+        &self,
+        keys: &dyn PublicKeysRepository,
+        revocation_info: &RevocationInfo,
+    ) -> Result<Ref<'_, T>, Error> {
         let borrow = self.verified_deserialized.borrow();
 
         if borrow.is_none() {
             let value = verify_signature(
+                keys,
+                &self.signatures,
+                PayloadBytes::borrowed(self.signed.as_bytes()),
+                revocation_info,
+            )?;
+
+            // In theory, `borrow_mut()` could panic if an immutable borrow was alive at the same
+            // time. In practice that won't happen, as we only populate the cache before returning
+            // any reference to the cached data.
+            drop(borrow);
+            *self.verified_deserialized.borrow_mut() = Some(value)
+        }
+
+        Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
+            b.as_ref().unwrap()
+        }))
+    }
+
+    /// Use this to verify only signed payloads that inherently do not require revocations checks.
+    /// Examples include Keys in the KeysManifest. Rest all should be checked with RevocationInfo
+    /// using get_verified.
+    pub fn get_verified_no_revocations_check(
+        &self,
+        keys: &dyn PublicKeysRepository,
+    ) -> Result<Ref<'_, T>, Error> {
+        let borrow = self.verified_deserialized.borrow();
+
+        if borrow.is_none() {
+            let value = verify_signature_no_revocations_check(
                 keys,
                 &self.signatures,
                 PayloadBytes::borrowed(self.signed.as_bytes()),
@@ -94,7 +105,7 @@ impl<T: Signable> SignedPayload<T> {
             // time. In practice that won't happen, as we only populate the cache before returning
             // any reference to the cached data.
             drop(borrow);
-            *self.verified_deserialized.borrow_mut() = Some(value);
+            *self.verified_deserialized.borrow_mut() = Some(value)
         }
 
         Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
@@ -108,11 +119,34 @@ impl<T: Signable> SignedPayload<T> {
     /// [`get_verified`](Self::get_verified) method), the cached deserialized payload will be
     /// returned. Otherwise, signature verification will be performed with the provided keychain
     /// before deserializing.
-    pub fn into_verified(self, keys: &dyn PublicKeysRepository) -> Result<T, Error> {
+    pub fn into_verified(
+        self,
+        keys: &dyn PublicKeysRepository,
+        revocation_info: &RevocationInfo,
+    ) -> Result<T, Error> {
         if let Some(deserialized) = self.verified_deserialized.into_inner() {
             Ok(deserialized)
         } else {
             verify_signature(
+                keys,
+                &self.signatures,
+                PayloadBytes::borrowed(self.signed.as_bytes()),
+                revocation_info,
+            )
+        }
+    }
+
+    /// Use this to verify only signed payloads that inherently do not require revocations checks.
+    /// Examples include Keys in the KeysManifest. Rest all should be checked with RevocationInfo
+    /// using into_verified.
+    pub fn into_verified_no_revocations_check(
+        self,
+        keys: &dyn PublicKeysRepository,
+    ) -> Result<T, Error> {
+        if let Some(deserialized) = self.verified_deserialized.into_inner() {
+            Ok(deserialized)
+        } else {
+            verify_signature_no_revocations_check(
                 keys,
                 &self.signatures,
                 PayloadBytes::borrowed(self.signed.as_bytes()),
@@ -125,6 +159,7 @@ fn verify_signature<T: Signable>(
     keys: &dyn PublicKeysRepository,
     signatures: &[Signature],
     signed: PayloadBytes<'_>,
+    revocation_info: &RevocationInfo,
 ) -> Result<T, Error> {
     for signature in signatures {
         let key = match keys.get(&signature.key_sha256) {
@@ -132,7 +167,37 @@ fn verify_signature<T: Signable>(
             None => continue,
         };
 
-        match key.verify(T::SIGNED_BY_ROLE, &signed, &signature.signature) {
+        match key.verify(
+            T::SIGNED_BY_ROLE,
+            &signed,
+            &signature.signature,
+            revocation_info,
+        ) {
+            Ok(()) => {}
+            Err(Error::VerificationFailed) => continue,
+            Err(other) => return Err(other),
+        }
+
+        // Deserialization is performed after the signature is verified, to ensure we are not
+        // deserializing malicious data.
+        return serde_json::from_slice(signed.as_bytes()).map_err(Error::DeserializationFailed);
+    }
+
+    Err(Error::VerificationFailed)
+}
+
+fn verify_signature_no_revocations_check<T: Signable>(
+    keys: &dyn PublicKeysRepository,
+    signatures: &[Signature],
+    signed: PayloadBytes<'_>,
+) -> Result<T, Error> {
+    for signature in signatures {
+        let key = match keys.get(&signature.key_sha256) {
+            Some(key) => key,
+            None => continue,
+        };
+
+        match key.verify_no_revocations_check(T::SIGNED_BY_ROLE, &signed, &signature.signature) {
             Ok(()) => {}
             Err(Error::VerificationFailed) => continue,
             Err(other) => return Err(other),
@@ -313,7 +378,10 @@ mod tests {
 
         assert_eq!(
             42,
-            payload.get_verified(test_env.keychain()).unwrap().answer
+            payload
+                .get_verified(test_env.keychain(), test_env.revocation_info())
+                .unwrap()
+                .answer
         );
 
         // If there was no caching, this method call would fail, as there is no valid key to
@@ -322,7 +390,10 @@ mod tests {
         assert_eq!(
             42,
             payload
-                .get_verified(TestEnvironment::prepare().keychain())
+                .get_verified(
+                    TestEnvironment::prepare().keychain(),
+                    test_env.revocation_info()
+                )
                 .unwrap()
                 .answer
         );
@@ -337,13 +408,13 @@ mod tests {
 
         let payload = prepare_payload(&[&key], r#"{"answer": 42"#);
         assert!(matches!(
-            payload.get_verified(test_env.keychain()),
+            payload.get_verified(test_env.keychain(), test_env.revocation_info()),
             Err(Error::DeserializationFailed(_))
         ));
 
         let payload = prepare_payload(&[&key], r#"{"answer": 42"#);
         assert!(matches!(
-            payload.into_verified(test_env.keychain()),
+            payload.into_verified(test_env.keychain(), test_env.revocation_info()),
             Err(Error::DeserializationFailed(_))
         ));
     }
@@ -389,7 +460,14 @@ mod tests {
             }"#,
         ).unwrap();
 
-        assert_eq!(42, payload.get_verified(&keychain).unwrap().answer);
+        let revocation_info = RevocationInfo::default();
+        assert_eq!(
+            42,
+            payload
+                .get_verified(&keychain, &revocation_info)
+                .unwrap()
+                .answer
+        );
     }
 
     // Utilities
@@ -400,7 +478,7 @@ mod tests {
         assert_eq!(
             42,
             get_payload
-                .get_verified(test_env.keychain())
+                .get_verified(test_env.keychain(), test_env.revocation_info())
                 .unwrap()
                 .answer
         );
@@ -410,7 +488,7 @@ mod tests {
         assert_eq!(
             42,
             into_payload
-                .into_verified(test_env.keychain())
+                .into_verified(test_env.keychain(), test_env.revocation_info())
                 .unwrap()
                 .answer
         );
@@ -420,14 +498,18 @@ mod tests {
     fn assert_verify_fail(test_env: &TestEnvironment, keys: &[&dyn KeyPair]) {
         let get_payload = prepare_payload(keys, SAMPLE_DATA);
         assert!(matches!(
-            get_payload.get_verified(test_env.keychain()).unwrap_err(),
+            get_payload
+                .get_verified(test_env.keychain(), test_env.revocation_info())
+                .unwrap_err(),
             Error::VerificationFailed
         ));
 
         // Two separate payloads are used to avoid caching.
         let into_payload = prepare_payload(keys, SAMPLE_DATA);
         assert!(matches!(
-            into_payload.into_verified(test_env.keychain()).unwrap_err(),
+            into_payload
+                .into_verified(test_env.keychain(), test_env.revocation_info())
+                .unwrap_err(),
             Error::VerificationFailed
         ));
     }

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -460,7 +460,7 @@ mod tests {
             }"#,
         ).unwrap();
 
-        let revocation_info = RevocationInfo::default();
+        let revocation_info = RevocationInfo::new();
         assert_eq!(
             42,
             payload

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -6,6 +6,7 @@ use crate::keys::{KeyId, KeyPair, KeyRole, PublicKey};
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use std::cell::{Ref, RefCell};
+use crate::manifests::RevocationInfo;
 
 /// Piece of data with signatures attached to it.
 ///
@@ -57,6 +58,28 @@ impl<T: Signable> SignedPayload<T> {
     /// As signature verification and deserialization is expensive, it is only performed the first
     /// time the method is called. The cached results from the initial call will be returned in the
     /// rest of the cases.
+    // pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
+    //     let borrow = self.verified_deserialized.borrow();
+    //
+    //     if borrow.is_none() {
+    //         let value = verify_signature(
+    //             keys,
+    //             &self.signatures,
+    //             PayloadBytes::borrowed(self.signed.as_bytes()),
+    //         )?;
+    //
+    //         // In theory, `borrow_mut()` could panic if an immutable borrow was alive at the same
+    //         // time. In practice that won't happen, as we only populate the cache before returning
+    //         // any reference to the cached data.
+    //         drop(borrow);
+    //         *self.verified_deserialized.borrow_mut() = Some(value);
+    //     }
+    //
+    //     Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
+    //         b.as_ref().unwrap()
+    //     }))
+    // }
+
     pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
         let borrow = self.verified_deserialized.borrow();
 

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -243,9 +243,11 @@ mod tests {
     use crate::manifests::{KeysManifest, ManifestVersion};
     use crate::signatures::Keychain;
     use crate::test_utils::{base64_encode, TestEnvironment};
-    use time::macros::datetime;
+    use time::{Duration, OffsetDateTime};
 
     const SAMPLE_DATA: &str = r#"{"answer":42}"#;
+    // Make sure there is enough number of days for expiration so tests don't need constant updates.
+    const EXPIRATION_EXTENSION_IN_DAYS: Duration = Duration::days(180);
 
     #[test]
     fn tets_verify_no_signatures() {
@@ -470,8 +472,10 @@ mod tests {
     fn test_verify_revocation_info() {
         let mut test_env = TestEnvironment::prepare();
         let key_revocation = test_env.create_key(KeyRole::Revocation);
-        let revoked_content =
-            RevocationInfo::new(vec![vec![1, 2, 3]], datetime!(2025-08-05 00:00 UTC));
+        let revoked_content = RevocationInfo::new(
+            vec![vec![1, 2, 3]],
+            OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
+        );
         let mut signed_revoked_content = SignedPayload::new(&revoked_content).unwrap();
         signed_revoked_content
             .add_signature(&key_revocation)
@@ -492,8 +496,10 @@ mod tests {
     fn test_verify_revocation_info_incorrect_keyrole() {
         let mut test_env = TestEnvironment::prepare();
         let key_not_revocation_role = test_env.create_key(KeyRole::Packages);
-        let revoked_content =
-            RevocationInfo::new(vec![vec![1, 2, 3]], datetime!(2025-08-05 00:00 UTC));
+        let revoked_content = RevocationInfo::new(
+            vec![vec![1, 2, 3]],
+            OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
+        );
         let mut signed_revoked_content = SignedPayload::new(&revoked_content).unwrap();
         signed_revoked_content
             .add_signature(&key_not_revocation_role)

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -188,7 +188,7 @@ fn verify_signature<T: Signable>(
     Err(Error::VerificationFailed)
 }
 
-fn verify_signature_no_revocations_check<T: Signable>(
+fn verify_signature_no_revocations_check<T: Signable + NoRevocationsCheck>(
     keys: &dyn PublicKeysRepository,
     signatures: &[Signature],
     signed: PayloadBytes<'_>,

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -462,11 +462,11 @@ mod tests {
             }"#,
         ).unwrap();
 
-        let revocation_info = RevocationInfo::new();
+        let revocation_info = keychain.revocation_info();
         assert_eq!(
             42,
             payload
-                .get_verified(&keychain, &revocation_info)
+                .get_verified(&keychain, revocation_info)
                 .unwrap()
                 .answer
         );

--- a/crates/criticaltrust/src/test_utils.rs
+++ b/crates/criticaltrust/src/test_utils.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::keys::{EphemeralKeyPair, KeyAlgorithm, KeyPair, KeyRole, PublicKey};
+use crate::revocation_info::RevocationInfo;
 use crate::signatures::{Keychain, SignedPayload};
 use base64::Engine;
 use time::{Duration, OffsetDateTime};
@@ -17,12 +18,15 @@ impl TestEnvironment {
     pub(crate) fn prepare() -> Self {
         let root = EphemeralKeyPair::generate(ALGORITHM, KeyRole::Root, None).unwrap();
         let keychain = Keychain::new(root.public()).unwrap();
-
         Self { root, keychain }
     }
 
     pub(crate) fn keychain(&self) -> &Keychain {
         &self.keychain
+    }
+
+    pub(crate) fn revocation_info(&self) -> &RevocationInfo {
+        self.keychain.revocation_info()
     }
 
     pub(crate) fn create_untrusted_key(&self, role: KeyRole) -> EphemeralKeyPair {

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use owo_colors::OwoColorize;
 
-use criticaltrust::integrity::IntegrityVerifier;
+use criticaltrust::integrity::{IntegrityError, IntegrityVerifier};
 use criticaltrust::manifests::{Release, ReleaseArtifactFormat};
 use criticalup_core::download_server_client::DownloadServerClient;
 use criticalup_core::project_manifest::{ProjectManifest, ProjectManifestProduct};
@@ -77,7 +77,9 @@ async fn install_product_afresh(
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
     let client = DownloadServerClient::new(&ctx.config, state);
     let keys = client.get_keys().await?;
-    let revocation_info = &keys.revocation_info();
+    let revocation_info = &keys
+        .revocation_info()
+        .ok_or_else(|| Error::MissingRevocationInfo(IntegrityError::MissingRevocationInfo))?;
 
     // TODO: Add tracing to support log levels, structured logging.
     println!(

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -77,6 +77,7 @@ async fn install_product_afresh(
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
     let client = DownloadServerClient::new(&ctx.config, state);
     let keys = client.get_keys().await?;
+    let revocation_info = keys.revocation_info();
 
     // TODO: Add tracing to support log levels, structured logging.
     println!(
@@ -90,7 +91,9 @@ async fn install_product_afresh(
     let release_manifest_from_server = client
         .get_product_release_manifest(product_name, product.release())
         .await?;
-    let verified_release_manifest = release_manifest_from_server.signed.into_verified(&keys)?;
+    let verified_release_manifest = release_manifest_from_server
+        .signed
+        .into_verified(&keys, revocation_info)?;
 
     // criticalup 0.1, return error if any of package.dependencies is not empty.
     // We have to use manifest's Release because the information about dependencies

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -77,7 +77,7 @@ async fn install_product_afresh(
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
     let client = DownloadServerClient::new(&ctx.config, state);
     let keys = client.get_keys().await?;
-    let revocation_info = keys.revocation_info();
+    let revocation_info = &keys.revocation_info();
 
     // TODO: Add tracing to support log levels, structured logging.
     println!(

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -42,6 +42,9 @@ pub(crate) enum Error {
     )]
     IntegrityErrorsWhileInstallation(Vec<IntegrityError>),
 
+    #[error(transparent)]
+    MissingRevocationInfo(#[from] IntegrityError),
+
     #[error("arg0 is not encoded in UTF-8")]
     NonUtf8Arg0,
     #[error("failed to invoke proxied command {}", .0.display())]

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::config::Config;
+use crate::errors::Error::KeychainLoadingFailed;
 use crate::errors::{DownloadServerError, Error};
 use crate::state::State;
 use criticaltrust::keys::PublicKey;
@@ -57,7 +58,10 @@ impl DownloadServerClient {
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
         let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
-        let _ = keychain.load_all(&resp);
+        match keychain.load_all(&resp) {
+            Ok(_) => {}
+            Err(e) => return Err(KeychainLoadingFailed(e)),
+        }
         Ok(keychain)
     }
 

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -53,10 +53,10 @@ impl DownloadServerClient {
     }
 
     pub async fn get_keys(&self) -> Result<Keychain, Error> {
-        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
         let resp: KeysManifest = self
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
+        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
         let _ = keychain.load_all(&resp);
         Ok(keychain)
     }

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -57,15 +57,7 @@ impl DownloadServerClient {
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
         let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
-        // TODO: actually capture the `KeysManifest::revoked_signatures` from the response.
-        let _ = keychain.load_with_revocation_check(&resp);
-        // for key in &resp.keys {
-        //     // Invalid keys are silently ignored, as they might be signed by a different root key
-        //     // used by a different release of criticalup, or they might be using an algorithm not
-        //     // supported by the current version of criticaltrust.
-        //     let _ = keychain.lock_and_load();
-        // }
-
+        let _ = keychain.load_all(&resp);
         Ok(keychain)
     }
 

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -53,17 +53,18 @@ impl DownloadServerClient {
     }
 
     pub async fn get_keys(&self) -> Result<Keychain, Error> {
-        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
-
         let resp: KeysManifest = self
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
-        for key in &resp.keys {
-            // Invalid keys are silently ignored, as they might be signed by a different root key
-            // used by a different release of criticalup, or they might be using an algorithm not
-            // supported by the current version of criticaltrust.
-            let _ = keychain.load(key);
-        }
+        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
+        // TODO: actually capture the `KeysManifest::revoked_signatures` from the response.
+        let _ = keychain.load_with_revocation_check(&resp);
+        // for key in &resp.keys {
+        //     // Invalid keys are silently ignored, as they might be signed by a different root key
+        //     // used by a different release of criticalup, or they might be using an algorithm not
+        //     // supported by the current version of criticaltrust.
+        //     let _ = keychain.lock_and_load();
+        // }
 
         Ok(keychain)
     }

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -74,6 +74,9 @@ pub enum Error {
         #[source]
         kind: std::io::Error,
     },
+
+    #[error("failed to load keys into keychain")]
+    KeychainLoadingFailed(#[source] criticaltrust::Error),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/mock-download-server/src/handlers.rs
+++ b/crates/mock-download-server/src/handlers.rs
@@ -4,9 +4,6 @@
 use crate::Serialize;
 use crate::{AuthenticationToken, Data};
 use criticaltrust::manifests::ManifestVersion;
-use criticaltrust::revocation_info::RevocationInfo;
-use criticaltrust::signatures::SignedPayload;
-use time::{Duration, OffsetDateTime};
 use tiny_http::{Header, Method, Request, Response, ResponseBox, StatusCode};
 
 pub(crate) fn handle_request(data: &Data, req: &Request) -> ResponseBox {
@@ -42,11 +39,7 @@ fn handle_v1_keys(data: &Data) -> Result<Resp, Resp> {
     Ok(Resp::json(&criticaltrust::manifests::KeysManifest {
         version: ManifestVersion,
         keys: data.keys.clone(),
-        revoked_signatures: SignedPayload::new(&RevocationInfo {
-            revoked_content_sha256: Vec::new(),
-            expires_at: OffsetDateTime::now_utc() + Duration::days(99),
-        })
-        .unwrap(),
+        revoked_signatures: data.revoked_signatures.clone(),
     }))
 }
 

--- a/crates/mock-download-server/src/handlers.rs
+++ b/crates/mock-download-server/src/handlers.rs
@@ -3,7 +3,8 @@
 
 use crate::Serialize;
 use crate::{AuthenticationToken, Data};
-use criticaltrust::manifests::{ManifestVersion, RevocationInfo};
+use criticaltrust::manifests::ManifestVersion;
+use criticaltrust::revocation_info::RevocationInfo;
 use criticaltrust::signatures::SignedPayload;
 use time::{Duration, OffsetDateTime};
 use tiny_http::{Header, Method, Request, Response, ResponseBox, StatusCode};

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -6,7 +6,8 @@ mod server;
 
 pub use crate::server::MockServer;
 use criticaltrust::keys::PublicKey;
-use criticaltrust::manifests::{ReleaseManifest, RevocationInfo};
+use criticaltrust::manifests::ReleaseManifest;
+use criticaltrust::revocation_info::RevocationInfo;
 use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -12,7 +12,10 @@ use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use time::macros::datetime;
+use time::{Duration, OffsetDateTime};
+
+// Make sure there is enough number of days for expiration so tests don't need constant updates.
+const EXPIRATION_EXTENSION_IN_DAYS: Duration = Duration::days(180);
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -36,7 +39,7 @@ pub fn new() -> Builder {
             keys: Vec::new(),
             revoked_signatures: SignedPayload::new(&RevocationInfo::new(
                 Vec::new(),
-                datetime!(3025-01-01 0:00 UTC),
+                OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
             ))
             .unwrap(),
             release_manifests: HashMap::new(),

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -36,7 +36,7 @@ pub fn new() -> Builder {
             keys: Vec::new(),
             revoked_signatures: SignedPayload::new(&RevocationInfo::new(
                 Vec::new(),
-                datetime!(2025-01-01 0:00 UTC),
+                datetime!(3025-01-01 0:00 UTC),
             ))
             .unwrap(),
             release_manifests: HashMap::new(),

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -12,6 +12,7 @@ use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use time::macros::datetime;
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -33,7 +34,10 @@ pub fn new() -> Builder {
         data: Data {
             tokens: HashMap::new(),
             keys: Vec::new(),
-            revoked_signatures: SignedPayload::new(&RevocationInfo::new()).unwrap(),
+            revoked_signatures: SignedPayload::new(&RevocationInfo::new(
+                datetime!(2025-01-01 0:00 UTC),
+            ))
+            .unwrap(),
             release_manifests: HashMap::new(),
         },
     }

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -35,6 +35,7 @@ pub fn new() -> Builder {
             tokens: HashMap::new(),
             keys: Vec::new(),
             revoked_signatures: SignedPayload::new(&RevocationInfo::new(
+                Vec::new(),
                 datetime!(2025-01-01 0:00 UTC),
             ))
             .unwrap(),


### PR DESCRIPTION
This PR is for me to ask questions and get feedback. I believe I have basic stuff implemented and before I actually write tests (will require test utils update). Here are the major changes I made (apart from pulling in async code from Ana).

- `Keychain` type now has additional member - `revocation_info`:- This allows for keeping the two things, keys and revocation info, together. They do come in together from the v1/keys endpoint. This also allows us to write one method that loads both keys and revocation info after verifying them. See `load_all` method.
- So, `download_server_client.rs` calls `load_all` instead and passes the entire `KeysManifest`.
- Created a standalone module for `RevocationInfo` called `revocation_info.rs`.
- At this point I'd rather keep duplicates in `payload.rs` - `verify_signature_no_revocations_check` and `verify_signature` than spend more time on it.
- The `get_verified` and `into_verified` have their counterparts in a more specific `impl`: `impl<T: Signable + NoRevocationsCheck> SignedPayload<T> {...}`.

Rest, I will comment on for your attention.