### PR TITLE
Cache installation tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+**CriticalUp is now travel and spotty internet friendly!** New retry and caching behavior, as well as
+an `--offline` mode for `criticalup install` means downloading new packages should be more reliable,
+and packages should not need to be redownloaded when used between multiple projects or toolchain
+reinstallation. *Now you can finally write automotive software while on a road trip into a remote part
+of the Pacific coast of Canada!*
+
 ## Added
 
-- Added `tracing` for structure and multi-level logging. `--verbose` and `-v` are now
+- An `--offline` flag has been added to `criticalup install`, when enabled only the download cache
+  will be used where possible, and the cache will not be populated on cache miss.
+- Caching of downloaded keys, manifests, and installation tarballs has been added. Newly downloaded
+  artifacts will also be stored in the OS-specific cache directory. The cache can be cleaned with
+  `criticalup clean` or any relevant OS behaviors.
+- `tracing` support was added for structured and multi-level logging. `--verbose` and `-v` are now
   generally accepted and enable debug logging. Passing the flag twice (eg. `-vv`) will enable
   trace logging as well. The `--log-level` argument can accept arbitrary
   [tracing directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-**CriticalUp is now travel and spotty internet friendly!** New retry and caching behavior, as well as
-an `--offline` mode for `criticalup install` means downloading new packages should be more reliable,
-and packages should not need to be redownloaded when used between multiple projects or toolchain
-reinstallation. *Now you can finally write automotive software while on a road trip into a remote part
-of the Pacific coast of Canada!*
-
 ## Added
 
 - An `--offline` flag has been added to `criticalup install`, when enabled only the download cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml_edit",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -102,7 +102,7 @@ pub struct ReleaseArtifact {
     pub sha256: Vec<u8>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Copy)]
 pub enum ReleaseArtifactFormat {
     #[serde(rename = "tar.zst")]
     TarZst,

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -4,9 +4,11 @@
 use crate::keys::{KeyId, KeyRole, PublicKey};
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Collection of all trusted public keys.
+#[derive(Serialize, Deserialize)]
 pub struct Keychain {
     keys: HashMap<KeyId, PublicKey>,
 }

--- a/crates/criticalup-cli/src/commands/clean.rs
+++ b/crates/criticalup-cli/src/commands/clean.rs
@@ -14,13 +14,22 @@ pub(crate) async fn run(ctx: &Context) -> Result<(), Error> {
     let installations_dir = &ctx.config.paths.installation_dir;
     let state = State::load(&ctx.config).await?;
 
+    delete_cache_directory(&ctx.config.paths.cache_dir).await?;
     delete_unused_installations(installations_dir, &state).await?;
     delete_untracked_installation_dirs(installations_dir, state).await?;
 
     Ok(())
 }
 
-/// Deletes installation from `State` wl; ith `InstallationId`s that have empty manifest section, and
+async fn delete_cache_directory(cache_dir: &Path) -> Result<(), Error> {
+    if cache_dir.exists() {
+        tracing::info!("Cleaning cache directory");
+        tokio::fs::remove_dir_all(&cache_dir).await?;
+    }
+    Ok(())
+}
+
+/// Deletes installation from `State` with `InstallationId`s that have empty manifest section, and
 /// deletes the installation directory from the disk if present.
 async fn delete_unused_installations(installations_dir: &Path, state: &State) -> Result<(), Error> {
     let unused_installations: Vec<InstallationId> = state

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use criticaltrust::integrity::IntegrityVerifier;
 use criticaltrust::manifests::{Release, ReleaseArtifactFormat};
-use criticalup_core::config::Config;
+use criticalup_core::download_server_cache::DownloadServerCache;
 use criticalup_core::download_server_client::DownloadServerClient;
 use criticalup_core::project_manifest::{ProjectManifest, ProjectManifestProduct};
 use criticalup_core::state::State;
@@ -20,12 +20,19 @@ pub const DEFAULT_RELEASE_ARTIFACT_FORMAT: ReleaseArtifactFormat = ReleaseArtifa
 pub(crate) async fn run(
     ctx: &Context,
     reinstall: bool,
+    offline: bool,
     project: Option<PathBuf>,
 ) -> Result<(), Error> {
     // TODO: If `std::io::stdout().is_terminal() == true``, provide a nice, fancy progress bar using indicatif.
     //       Retain existing behavior to support non-TTY usage.
 
     let state = State::load(&ctx.config).await?;
+    let maybe_client = if !offline {
+        Some(DownloadServerClient::new(&ctx.config, &state))
+    } else {
+        None
+    };
+    let cache = DownloadServerCache::new(&ctx.config.paths.cache_dir, &maybe_client).await?;
 
     // Get manifest location if arg `project` is None
     let manifest_path = ProjectManifest::discover_canonical_path(project.as_deref()).await?;
@@ -39,7 +46,7 @@ pub(crate) async fn run(
         let abs_installation_dir_path = installation_dir.join(product.installation_id());
 
         if !abs_installation_dir_path.exists() {
-            install_product_afresh(ctx, &state, &manifest_path, product).await?;
+            install_product_afresh(ctx, &state, &cache, &manifest_path, product).await?;
         } else {
             // Check if the state file has no mention of this installation.
             let does_this_installation_exist_in_state = state
@@ -48,7 +55,7 @@ pub(crate) async fn run(
             if !does_this_installation_exist_in_state || reinstall {
                 // If the installation directory exists, but the State has no installation of that
                 // InstallationId, then re-run the install command and go through installation.
-                install_product_afresh(ctx, &state, &manifest_path, product).await?;
+                install_product_afresh(ctx, &state, &cache, &manifest_path, product).await?;
             } else {
                 // If the installation directory exists AND there is an existing installation with
                 // that InstallationId, then merely update the installation in the State file to
@@ -78,6 +85,7 @@ pub(crate) async fn run(
 async fn install_product_afresh(
     ctx: &Context,
     state: &State,
+    cache: &DownloadServerCache<'_>,
     manifest_path: &Path,
     product: &ProjectManifestProduct,
 ) -> Result<(), Error> {
@@ -85,17 +93,15 @@ async fn install_product_afresh(
     let release = product.release();
     let installation_dir = &ctx.config.paths.installation_dir;
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
-    let client = DownloadServerClient::new(&ctx.config, state);
-    let keys = client.get_keys().await?;
+    let keys = cache.keys().await?;
 
-    // TODO: Add tracing to support log levels, structured logging.
     tracing::info!("Installing product '{product_name}' ({release})",);
 
     let mut integrity_verifier = IntegrityVerifier::new(&keys);
 
     // Get the release manifest for the product from the server and verify it.
-    let release_manifest_from_server = client
-        .get_product_release_manifest(product_name, product.release())
+    let release_manifest_from_server = cache
+        .product_release_manifest(product_name, product.release())
         .await?;
     let verified_release_manifest = release_manifest_from_server.signed.into_verified(&keys)?;
 
@@ -111,38 +117,19 @@ async fn install_product_afresh(
         .await?;
 
     for package in product.packages() {
-        let abs_artifact_compressed_file_path =
-            cached_package_path(&ctx.config, product.name(), release, package);
-
-        let package_file = if !abs_artifact_compressed_file_path.exists() {
-            tracing::info!("downloading component '{package}' for '{product_name}' ({release})",);
-            let package_file = client
-                .download_package(
-                    product_name,
-                    release_name,
-                    package,
-                    DEFAULT_RELEASE_ARTIFACT_FORMAT,
-                )
-                .await?;
-
-            // Save the downloaded package archive on disk.
-            tracing::debug!(cached = %abs_artifact_compressed_file_path.display(), "Writing package to cache");
-            let dest_dir = abs_artifact_compressed_file_path
-                .parent()
-                .ok_or_else(|| Error::NoParent(abs_artifact_compressed_file_path.clone()))?;
-            tokio::fs::create_dir_all(dest_dir).await?;
-            tokio::fs::write(&abs_artifact_compressed_file_path, &package_file).await?;
-
-            package_file
-        } else {
-            // Don't output anything normally, the lack of a "downloading" message is sufficient.
-            tracing::debug!(cached = %abs_artifact_compressed_file_path.display(), "Retrieving package from cache");
-            read(abs_artifact_compressed_file_path).await?
-        };
+        let package_path = cache
+            .package(
+                product_name,
+                release_name,
+                package,
+                DEFAULT_RELEASE_ARTIFACT_FORMAT,
+            )
+            .await?;
 
         tracing::info!("Installing component '{package}' for '{product_name}' ({release})",);
+        let package_data = read(package_path).await?;
 
-        let decoder = xz2::read::XzDecoder::new(package_file.as_slice());
+        let decoder = xz2::read::XzDecoder::new(package_data.as_slice());
         let mut archive = tar::Archive::new(decoder);
         archive.set_preserve_permissions(true);
         archive.set_preserve_mtime(true);
@@ -177,18 +164,6 @@ async fn install_product_afresh(
         &ctx.config,
     )?;
     Ok(())
-}
-
-pub fn cached_package_path(
-    config: &Config,
-    product: &str,
-    release: &str,
-    package: &str,
-) -> PathBuf {
-    let release_path = PathBuf::from(product).join(release);
-    let package_file = PathBuf::from(format!("{package}.tar.xz"));
-    let cache_key = release_path.join(package_file);
-    config.paths.cache_dir.join(cache_key)
 }
 
 fn check_for_package_dependencies(verified_release_manifest: &Release) -> Result<(), Error> {

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -3,9 +3,9 @@
 
 use std::path::{Path, PathBuf};
 
-use criticalup_core::config::Config;
 use criticaltrust::integrity::IntegrityVerifier;
 use criticaltrust::manifests::{Release, ReleaseArtifactFormat};
+use criticalup_core::config::Config;
 use criticalup_core::download_server_client::DownloadServerClient;
 use criticalup_core::project_manifest::{ProjectManifest, ProjectManifestProduct};
 use criticalup_core::state::State;
@@ -115,9 +115,7 @@ async fn install_product_afresh(
             cached_package_path(&ctx.config, product.name(), release, package);
 
         let package_file = if !abs_artifact_compressed_file_path.exists() {
-            tracing::info!(
-                "downloading component '{package}' for '{product_name}' ({release})",
-            );
+            tracing::info!("downloading component '{package}' for '{product_name}' ({release})",);
             let package_file = client
                 .download_package(
                     product_name,

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -22,9 +22,6 @@ pub(crate) enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error("could not get parent of `{}`", .0.display())]
-    NoParent(PathBuf),
-
     #[error(transparent)]
     JoinPaths(#[from] std::env::JoinPathsError),
 

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -22,6 +22,9 @@ pub(crate) enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
+    #[error("could not get parent of `{}`", .0.display())]
+    NoParent(PathBuf),
+
     #[error(transparent)]
     JoinPaths(#[from] std::env::JoinPathsError),
 

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -55,9 +55,11 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
             Some(AuthCommands::Remove) => commands::auth_remove::run(&ctx).await?,
             None => commands::auth::run(&ctx).await?,
         },
-        Commands::Install { project, reinstall } => {
-            commands::install::run(&ctx, reinstall, project).await?
-        }
+        Commands::Install {
+            project,
+            reinstall,
+            offline,
+        } => commands::install::run(&ctx, reinstall, offline, project).await?,
         Commands::Clean => commands::clean::run(&ctx).await?,
         Commands::Remove { project } => commands::remove::run(&ctx, project).await?,
         Commands::Run { command, project } => commands::run::run(&ctx, command, project).await?,
@@ -136,6 +138,9 @@ enum Commands {
         /// Reinstall products that may have already been installed
         #[arg(long)]
         reinstall: bool,
+        /// Don't download from the server, only use previously cached artifacts
+        #[arg(long)]
+        offline: bool,
     },
 
     /// Delete all unused and untracked installations

--- a/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
@@ -16,6 +16,7 @@ Usage:
 Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`
       --reinstall                   Reinstall products that may have already been installed
+      --offline                     Don't download from the server, only use previously cached artifacts
   -v, --verbose...                  Enable debug logs, -vv for trace
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help

--- a/crates/criticalup-core/Cargo.toml
+++ b/crates/criticalup-core/Cargo.toml
@@ -21,6 +21,7 @@ dirs = { version = "5.0.1", default-features = false }
 tokio.workspace = true
 reqwest-middleware.workspace = true
 reqwest-retry.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 mock-download-server = { path = "../mock-download-server" }

--- a/crates/criticalup-core/src/config/mod.rs
+++ b/crates/criticalup-core/src/config/mod.rs
@@ -21,20 +21,21 @@ pub struct Config {
 impl Config {
     /// Detect and load the criticalup configuration from the execution environment.
     pub fn detect(whitelabel: WhitelabelConfig) -> Result<Self, Error> {
-        Self::detect_inner(whitelabel, None)
+        Self::detect_inner(whitelabel, None, None)
     }
 
     fn detect_inner(
         whitelabel: WhitelabelConfig,
         root: Option<std::path::PathBuf>,
+        cache_dir: Option<std::path::PathBuf>,
     ) -> Result<Self, Error> {
-        let paths = Paths::detect(&whitelabel, root)?;
+        let paths = Paths::detect(&whitelabel, root, cache_dir)?;
         Ok(Self { whitelabel, paths })
     }
 
     #[cfg(test)]
-    pub(crate) fn test(root: std::path::PathBuf) -> Result<Self, Error> {
-        Self::detect_inner(WhitelabelConfig::test(), Some(root))
+    pub(crate) fn test(root: std::path::PathBuf, cache_dir: std::path::PathBuf) -> Result<Self, Error> {
+        Self::detect_inner(WhitelabelConfig::test(), Some(root), Some(cache_dir))
     }
 }
 

--- a/crates/criticalup-core/src/config/mod.rs
+++ b/crates/criticalup-core/src/config/mod.rs
@@ -34,7 +34,10 @@ impl Config {
     }
 
     #[cfg(test)]
-    pub(crate) fn test(root: std::path::PathBuf, cache_dir: std::path::PathBuf) -> Result<Self, Error> {
+    pub(crate) fn test(
+        root: std::path::PathBuf,
+        cache_dir: std::path::PathBuf,
+    ) -> Result<Self, Error> {
         Self::detect_inner(WhitelabelConfig::test(), Some(root), Some(cache_dir))
     }
 }

--- a/crates/criticalup-core/src/config/paths.rs
+++ b/crates/criticalup-core/src/config/paths.rs
@@ -38,14 +38,16 @@ impl Paths {
 
         let cache_dir = match cache_dir {
             Some(cache_dir) => cache_dir,
-            None => find_cache_dir(whitelabel).ok_or_else(|| Error::CouldNotDetectCacheDirectory)?,
+            None => {
+                find_cache_dir(whitelabel).ok_or_else(|| Error::CouldNotDetectCacheDirectory)?
+            }
         };
 
         Ok(Paths {
             state_file: root.join("state.json"),
             proxies_dir: root.join("bin"),
             installation_dir: root.join(DEFAULT_INSTALLATION_DIR_NAME),
-            cache_dir: cache_dir,
+            cache_dir,
             #[cfg(test)]
             root,
         })
@@ -95,7 +97,12 @@ mod tests {
                 cache_dir: "/cache/criticalup".into(),
                 root: "/opt/criticalup".into()
             },
-            Paths::detect(&WhitelabelConfig::test(), Some("/opt/criticalup".into()), Some("/cache/criticalup".into())).unwrap()
+            Paths::detect(
+                &WhitelabelConfig::test(),
+                Some("/opt/criticalup".into()),
+                Some("/cache/criticalup".into())
+            )
+            .unwrap()
         );
     }
 

--- a/crates/criticalup-core/src/download_server_cache.rs
+++ b/crates/criticalup-core/src/download_server_cache.rs
@@ -28,11 +28,7 @@ impl<'a> DownloadServerCache<'a> {
         Ok(Self { root, client })
     }
 
-    fn release_path(
-        &self,
-        product: &str,
-        release: &str,
-    ) -> PathBuf {
+    fn release_path(&self, product: &str, release: &str) -> PathBuf {
         self.root.join("artifacts").join(product).join(release)
     }
 
@@ -50,17 +46,11 @@ impl<'a> DownloadServerCache<'a> {
         })
     }
 
-    fn product_release_manfest_path(
-        &self,
-        product: &str,
-        release: &str,
-    ) -> PathBuf {
+    fn product_release_manfest_path(&self, product: &str, release: &str) -> PathBuf {
         self.release_path(product, release).join("manifest.json")
     }
 
-    fn keys_path(
-        &self,
-    ) -> PathBuf {
+    fn keys_path(&self) -> PathBuf {
         self.root.join("keys.json")
     }
 

--- a/crates/criticalup-core/src/download_server_cache.rs
+++ b/crates/criticalup-core/src/download_server_cache.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{download_server_client::DownloadServerClient, errors::Error};
+use std::path::{Path, PathBuf};
+
+use criticaltrust::{
+    manifests::{ReleaseArtifactFormat, ReleaseManifest},
+    signatures::Keychain,
+};
+use tokio::fs::{create_dir_all, read, write};
+
+/// A cache for artifacts from the download server
+pub struct DownloadServerCache<'a> {
+    root: &'a Path,
+    /// The cache will lazily populate if provided a client.
+    client: Option<&'a DownloadServerClient>,
+}
+
+impl<'a> DownloadServerCache<'a> {
+    /// Create a new cache from a given root, and optionally a client.
+    pub async fn new(
+        root: &'a Path,
+        client: impl Into<Option<&'a DownloadServerClient>>,
+    ) -> Result<Self, Error> {
+        let client = client.into();
+
+        Ok(Self { root, client })
+    }
+
+    fn release_path(
+        &self,
+        product: &str,
+        release: &str,
+    ) -> PathBuf {
+        self.root.join("artifacts").join(product).join(release)
+    }
+
+    fn package_path(
+        &self,
+        product: &str,
+        release: &str,
+        package: &str,
+        format: ReleaseArtifactFormat,
+    ) -> PathBuf {
+        self.release_path(product, release).join({
+            let mut file_name = PathBuf::from(package);
+            file_name.set_extension(format.to_string());
+            file_name
+        })
+    }
+
+    fn product_release_manfest_path(
+        &self,
+        product: &str,
+        release: &str,
+    ) -> PathBuf {
+        self.release_path(product, release).join("manifest.json")
+    }
+
+    fn keys_path(
+        &self,
+    ) -> PathBuf {
+        self.root.join("keys.json")
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(
+        %product,
+        %release,
+        %package,
+        %format
+    ))]
+    pub async fn package(
+        &self,
+        product: &str,
+        release: &str,
+        package: &str,
+        format: ReleaseArtifactFormat,
+    ) -> Result<PathBuf, Error> {
+        let cache_key = self.package_path(product, release, package, format);
+
+        let cache_hit = cache_key.exists();
+        tracing::trace!(%cache_hit, cache_key = %cache_key.display());
+
+        match (cache_hit, &self.client) {
+            (false, Some(client)) => {
+                // Cache miss, online mode
+                let cache_dir = self.release_path(product, release);
+                create_dir_all(&cache_dir)
+                    .await
+                    .map_err(|e| Error::Create(cache_dir.to_path_buf(), e))?;
+
+                let download = client
+                    .download_package(product, release, package, format)
+                    .await?;
+                tokio::fs::write(&cache_key, download)
+                    .await
+                    .map_err(|e| Error::Write(cache_key.clone(), e))?;
+            }
+            (false, None) => {
+                // Cache miss, offline mode
+                return Err(Error::OfflineMode);
+            }
+            (true, _) => (), // Cache hit
+        }
+
+        Ok(cache_key)
+    }
+
+    #[tracing::instrument(level = "debug", skip_all, fields(
+        %product,
+        %release,
+    ))]
+    pub async fn product_release_manifest(
+        &self,
+        product: &str,
+        release: &str,
+    ) -> Result<ReleaseManifest, Error> {
+        let cache_key = self.product_release_manfest_path(product, release);
+
+        let cache_hit = cache_key.exists();
+        tracing::trace!(%cache_hit, cache_key = %cache_key.display());
+
+        let data = match (cache_hit, &self.client) {
+            (false, Some(client)) => {
+                // Cache miss, online mode
+                let cache_dir = self.release_path(product, release);
+                create_dir_all(&cache_dir)
+                    .await
+                    .map_err(|e| Error::Create(cache_dir.to_path_buf(), e))?;
+
+                let data = client
+                    .get_product_release_manifest(product, release)
+                    .await?;
+                // It would be preferable to store the raw server response.
+                let serialized = serde_json::to_string_pretty(&data)?;
+                write(&cache_key, serialized)
+                    .await
+                    .map_err(|e| Error::Write(cache_key.clone(), e))?;
+                data
+            }
+            (false, None) => {
+                // Cache miss, offline mode
+                return Err(Error::OfflineMode);
+            }
+            (true, _) => {
+                // Cache hit
+                let data = read(&cache_key)
+                    .await
+                    .map_err(|e| Error::Read(cache_key.clone(), e))?;
+                serde_json::from_slice(&data)?
+            }
+        };
+
+        Ok(data)
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn keys(&self) -> Result<Keychain, Error> {
+        let cache_key = self.keys_path();
+
+        let cache_hit = cache_key.exists();
+        tracing::trace!(%cache_hit, cache_key = %cache_key.display());
+
+        let data = match (cache_hit, &self.client) {
+            (false, Some(client)) => {
+                // Cache miss, online mode
+                create_dir_all(&self.root)
+                    .await
+                    .map_err(|e| Error::Create(self.root.to_path_buf(), e))?;
+
+                let data = client.get_keys().await?;
+                // It would be preferable to store the raw server response.
+                let serialized = serde_json::to_string_pretty(&data)?;
+                write(&cache_key, serialized)
+                    .await
+                    .map_err(|e| Error::Write(cache_key.clone(), e))?;
+                data
+            }
+            (false, None) => {
+                // Cache miss, offline mode
+                return Err(Error::OfflineMode);
+            }
+            (true, _) => {
+                // Cache hit
+                let data = read(&cache_key)
+                    .await
+                    .map_err(|e| Error::Read(cache_key.clone(), e))?;
+                serde_json::from_slice(&data)?
+            }
+        };
+
+        Ok(data)
+    }
+}

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -52,6 +52,7 @@ impl DownloadServerClient {
         .await
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn get_keys(&self) -> Result<Keychain, Error> {
         let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
 
@@ -68,6 +69,10 @@ impl DownloadServerClient {
         Ok(keychain)
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(
+        %product,
+        %release,
+    ))]
     pub async fn get_product_release_manifest(
         &self,
         product: &str,
@@ -81,6 +86,12 @@ impl DownloadServerClient {
         .await
     }
 
+    #[tracing::instrument(level = "debug", skip_all, fields(
+        %product,
+        %release,
+        %package,
+        %format
+    ))]
     pub async fn download_package(
         &self,
         product: &str,
@@ -93,6 +104,7 @@ impl DownloadServerClient {
         let download_url =
             format!("/v1/releases/{product}/{release}/download/{package}/{artifact_format}");
 
+        tracing::info!("Downloading component '{package}' for '{product}' ({release})",);
         let response = self
             .send_with_auth(self.client.get(self.url(download_url.as_str())))
             .await?;

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -15,6 +15,9 @@ pub enum Error {
     #[error("could not detect the criticalup root directory")]
     CouldNotDetectRootDirectory,
 
+    #[error("could not detect the criticalup cache directory")]
+    CouldNotDetectCacheDirectory,
+
     #[error("failed to download {url}")]
     DownloadServerError {
         url: String,

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -25,6 +25,21 @@ pub enum Error {
         kind: DownloadServerError,
     },
 
+    #[error("Network access required, but in offline mode")]
+    OfflineMode,
+
+    #[error("Creating `{}`", .0.display())]
+    Create(PathBuf, #[source] std::io::Error),
+
+    #[error("Writing to `{}`", .0.display())]
+    Write(PathBuf, #[source] std::io::Error),
+
+    #[error("Reading from `{}`", .0.display())]
+    Read(PathBuf, #[source] std::io::Error),
+
+    #[error("JSON Serialization error")]
+    JsonSerialization(#[from] serde_json::Error),
+
     #[error("state file at {} is not supported by this release (state format version {1})", .0.display())]
     UnsupportedStateFileVersion(PathBuf, u32),
     #[error("failed to read the criticalup state file at {}", .0.display())]

--- a/crates/criticalup-core/src/lib.rs
+++ b/crates/criticalup-core/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod binary_proxies;
 pub mod config;
+pub mod download_server_cache;
 pub mod download_server_client;
 pub mod errors;
 pub mod project_manifest;

--- a/crates/criticalup-core/src/lib.rs
+++ b/crates/criticalup-core/src/lib.rs
@@ -6,7 +6,6 @@ pub mod config;
 pub mod download_server_client;
 pub mod errors;
 pub mod project_manifest;
-
 pub mod state;
 
 mod utils;

--- a/crates/criticalup-core/src/project_manifest/mod.rs
+++ b/crates/criticalup-core/src/project_manifest/mod.rs
@@ -11,6 +11,7 @@ use crate::project_manifest::substitutions::apply_substitutions;
 use crate::utils::Sha256Hasher;
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -211,6 +212,12 @@ impl Deref for InstallationId {
 
     fn deref(&self) -> &Self::Target {
         self.0.as_str()
+    }
+}
+
+impl Display for InstallationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/crates/criticalup-core/src/test_utils.rs
+++ b/crates/criticalup-core/src/test_utils.rs
@@ -100,12 +100,18 @@ impl TestEnvironmentBuilder {
     pub(crate) async fn prepare(self) -> TestEnvironment {
         #[cfg(not(target_os = "windows"))]
         let root = TempDir::new().expect("failed to create temp dir");
-
         #[cfg(target_os = "windows")]
         let root =
             TempDir::new_in(std::env::current_dir().unwrap()).expect("failed to create temp dir");
-
         let mut root_path = root.path().to_path_buf();
+
+        #[cfg(not(target_os = "windows"))]
+        let cache = TempDir::new().expect("failed to create temp dir");
+        #[cfg(target_os = "windows")]
+        let cache =
+            TempDir::new_in(std::env::current_dir().unwrap()).expect("failed to create temp dir");
+        let cache_path = cache.path().to_path_buf();
+
         if let Some(subdir) = self.root_in_subdir {
             // A subdir creation is a requirement because root cannot be changed to anything
             // that does not exist.
@@ -115,7 +121,7 @@ impl TestEnvironmentBuilder {
             root_path = root_path.join(subdir);
         }
 
-        let mut config = Config::test(root_path).expect("failed to create config");
+        let mut config = Config::test(root_path, cache_path).expect("failed to create config");
 
         let keys = if self.keys {
             let keys = TestKeys::generate();

--- a/docs/src/using-criticalup/toolchain-management.rst
+++ b/docs/src/using-criticalup/toolchain-management.rst
@@ -83,6 +83,9 @@ Then run the install command again:
 
    criticalup install
 
+When an internet connection is not available, a previously installed package
+can be reinstalled without using the network by passing the ``--offline`` flag.
+
 Removing Toolchains
 ^^^^^^^^^^^^^^^^^^^
 
@@ -97,9 +100,9 @@ from the directory containing the ``criticalup.toml``:
 Cleaning Unused Toolchains
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Over time CriticalUp's stored installations may accumulate artifacts that
-are no longer used. If CriticalUp's state directory begins to consume too much
-disk space the ``clean`` command can help by deleting unused toolchains.
+Over time CriticalUp's stored installations or cache may accumulate artifacts
+that are no longer used. If CriticalUp's state directory begins to consume too
+much disk space the ``clean`` command can help by deleting unused toolchains.
 
 
 .. code-block::


### PR DESCRIPTION
Adopts a strategy of caching installed packages, manifests, and keys to the decided OS cache directory and then using those if present by way of a `DownloadServerCache` which wraps a `DownloadServerClient` and provides a very similar albeit restricted API.

Alters `criticalup clean` to appropriately clean the cache directory.

Adds an `--offline` flag to `criticalup install`.