### PR TITLE
Revocation Checks - Call Revocation check on call site like installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ## Added
 
+- Support for package revocation added, `criticalup install` will verify packages have not been
+  revoked (due to, for example, a security event) before installation.
 - An `--offline` flag has been added to `criticalup install`, when enabled only the download cache
   will be used where possible, and the cache will not be populated on cache miss.
 - Caching of downloaded keys, manifests, and installation tarballs has been added. Newly downloaded

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-targets 0.52.5",
 ]
 
@@ -676,6 +677,7 @@ dependencies = [
  "rand_core",
  "serde",
  "serde_json",
+ "serde_with",
  "sha2",
  "thiserror",
  "time",
@@ -763,6 +765,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1066,12 +1103,18 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1305,6 +1348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,12 +1365,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2256,6 +2317,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,7 +2649,7 @@ version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/criticaltrust/Cargo.toml
+++ b/crates/criticaltrust/Cargo.toml
@@ -15,6 +15,7 @@ p256 = { version = "0.13.2", features = ["ecdsa-core"]  }
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
+serde_with = { version = "3.9.0", features = ["base64"]}
 sha2 = "0.10.8"
 thiserror = "1.0.61"
 time = { version = "0.3.36", features = ["std", "serde", "serde-well-known", "macros"] }

--- a/crates/criticaltrust/Cargo.toml
+++ b/crates/criticaltrust/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 sha2 = "0.10.8"
 thiserror = "1.0.61"
-time = { version = "0.3.36", features = ["std", "serde", "serde-well-known"] }
+time = { version = "0.3.36", features = ["std", "serde", "serde-well-known", "macros"] }
 aws-config = { version = "1.5.0", optional = true, features = ["rustls", "behavior-version-latest"] }
 aws-sdk-kms = { version = "1.28.0", optional = true, features = ["rustls"] }
 aws-smithy-runtime-api = { version = "1.6.1", optional = true }

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -28,6 +28,8 @@ pub enum Error {
     UnsupportedKey,
     #[error("verification failed because the signatures expired")]
     SignaturesExpired,
+    #[error("revocation info is expired")]
+    RevocationSignatureExpired,
     #[error("failed to verify signed data because payload is revoked")]
     ContentRevoked,
     #[cfg(feature = "aws-kms")]

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -4,6 +4,8 @@
 use crate::keys::KeyRole;
 use std::string::FromUtf8Error;
 use thiserror::Error;
+use time::macros::format_description;
+use time::OffsetDateTime;
 
 #[non_exhaustive]
 #[derive(Debug, Error)]
@@ -26,12 +28,10 @@ pub enum Error {
     InvalidKey(String),
     #[error("unsupported key")]
     UnsupportedKey,
-    #[error("verification failed because the signatures expired")]
-    SignaturesExpired,
-    #[error("revocation info is expired")]
-    RevocationSignatureExpired,
-    #[error("failed to verify signed data because payload is revoked")]
-    ContentRevoked,
+    #[error("verification failed because the signatures expired on '{}'", format!("{}", .0.format(format_description!("[year]-[month]-[day] +[offset_hour]::[offset_minute]")).expect("formatting OffsetDatetime failed")))]
+    RevocationSignatureExpired(OffsetDateTime),
+    #[error("failed to verify signed package '{}' because content is revoked", .0)]
+    ContentRevoked(String),
     #[error("calling the method to load all keys and revocation info failed because revocation info already exists.")]
     RevocationInfoOverwriting,
     #[cfg(feature = "aws-kms")]

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -30,8 +30,6 @@ pub enum Error {
     SignaturesExpired,
     #[error("failed to verify signed data because payload is revoked")]
     ContentRevoked,
-    #[error("failed to calculate SHA256 from payload")]
-    PayloadSha256CalcFailed(#[source] FromUtf8Error),
     #[cfg(feature = "aws-kms")]
     #[error("failed to retrieve the public key from AWS KMS")]
     AwsKmsFailedToGetPublicKey(

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -32,6 +32,8 @@ pub enum Error {
     RevocationSignatureExpired,
     #[error("failed to verify signed data because payload is revoked")]
     ContentRevoked,
+    #[error("calling the method to load all keys and revocation info failed because revocation info already exists.")]
+    RevocationInfoOverwriting,
     #[cfg(feature = "aws-kms")]
     #[error("failed to retrieve the public key from AWS KMS")]
     AwsKmsFailedToGetPublicKey(

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 #[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error(transparent)]
+    FromUtf8(#[from] FromUtf8Error),
     #[error("failed to sign data")]
     SignatureFailed,
     #[error("failed to verify signed data")]

--- a/crates/criticaltrust/src/errors.rs
+++ b/crates/criticaltrust/src/errors.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::keys::KeyRole;
+use std::string::FromUtf8Error;
 use thiserror::Error;
 
 #[non_exhaustive]
@@ -23,6 +24,12 @@ pub enum Error {
     InvalidKey(String),
     #[error("unsupported key")]
     UnsupportedKey,
+    #[error("verification failed because the signatures expired")]
+    SignaturesExpired,
+    #[error("failed to verify signed data because payload is revoked")]
+    ContentRevoked,
+    #[error("failed to calculate SHA256 from payload")]
+    PayloadSha256CalcFailed(#[source] FromUtf8Error),
     #[cfg(feature = "aws-kms")]
     #[error("failed to retrieve the public key from AWS KMS")]
     AwsKmsFailedToGetPublicKey(

--- a/crates/criticaltrust/src/integrity/mod.rs
+++ b/crates/criticaltrust/src/integrity/mod.rs
@@ -49,4 +49,6 @@ pub enum IntegrityError {
     FileReferencedByMultipleManifests { path: PathBuf },
     #[error("file {path} was loaded multiple times")]
     FileLoadedMultipleTimes { path: PathBuf },
+    #[error("revocation information is missing which is required to verify")]
+    MissingRevocationInfo,
 }

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -136,13 +136,17 @@ impl<'a> IntegrityVerifier<'a> {
         found: &FoundPackageManifest,
         contents: &[u8],
     ) -> Result<(), IntegrityError> {
+        let revocation_info = self
+            .keychain
+            .revocation_info()
+            .ok_or_else(|| IntegrityError::MissingRevocationInfo)?;
         let manifest = serde_json::from_slice::<PackageManifest>(contents)
             .map_err(|e| IntegrityError::PackageManifestDeserialization {
                 path: path.into(),
                 inner: e,
             })?
             .signed
-            .into_verified(self.keychain, self.keychain.revocation_info())
+            .into_verified(self.keychain, &revocation_info)
             .map_err(|e| IntegrityError::PackageManifestVerification {
                 path: path.into(),
                 inner: e,

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -142,7 +142,7 @@ impl<'a> IntegrityVerifier<'a> {
                 inner: e,
             })?
             .signed
-            .into_verified(self.keychain)
+            .into_verified(self.keychain, self.keychain.revocation_info())
             .map_err(|e| IntegrityError::PackageManifestVerification {
                 path: path.into(),
                 inner: e,

--- a/crates/criticaltrust/src/integrity/verifier.rs
+++ b/crates/criticaltrust/src/integrity/verifier.rs
@@ -136,17 +136,13 @@ impl<'a> IntegrityVerifier<'a> {
         found: &FoundPackageManifest,
         contents: &[u8],
     ) -> Result<(), IntegrityError> {
-        let revocation_info = self
-            .keychain
-            .revocation_info()
-            .ok_or_else(|| IntegrityError::MissingRevocationInfo)?;
         let manifest = serde_json::from_slice::<PackageManifest>(contents)
             .map_err(|e| IntegrityError::PackageManifestDeserialization {
                 path: path.into(),
                 inner: e,
             })?
             .signed
-            .into_verified(self.keychain, &revocation_info)
+            .into_verified(self.keychain)
             .map_err(|e| IntegrityError::PackageManifestVerification {
                 path: path.into(),
                 inner: e,

--- a/crates/criticaltrust/src/keys/pair_aws_kms.rs
+++ b/crates/criticaltrust/src/keys/pair_aws_kms.rs
@@ -116,7 +116,7 @@ mod tests {
     fn test_roundtrip() {
         let localstack = Localstack::init();
         let key = localstack.create_key(KeySpec::EccNistP256);
-        let signed_revocation_info = RevocationInfo::new(datetime!(2025-01-01 0:00 UTC));
+        let signed_revocation_info = RevocationInfo::new(vec![], datetime!(2025-01-01 0:00 UTC));
 
         let keypair = AwsKmsKeyPair::new(
             &key,

--- a/crates/criticaltrust/src/keys/pair_aws_kms.rs
+++ b/crates/criticaltrust/src/keys/pair_aws_kms.rs
@@ -100,13 +100,13 @@ impl KeyPair for AwsKmsKeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::revocation_info::RevocationInfo;
     use aws_sdk_kms::config::Credentials;
     use aws_sdk_kms::types::KeyUsageType;
     use rand_core::{OsRng, RngCore};
     use std::process::Command;
     use std::sync::Once;
     use tokio::runtime::Runtime;
-
     // We want to have tests for all of criticaltrust, which makes testing the integration with AWS
     // KMS quite tricky. To make it work, the tests for this module spawn a Docker container for
     // "localstack", a local replica of AWS services meant for testing.
@@ -115,6 +115,7 @@ mod tests {
     fn test_roundtrip() {
         let localstack = Localstack::init();
         let key = localstack.create_key(KeySpec::EccNistP256);
+        let signed_revocation_info = RevocationInfo::new();
 
         let keypair = AwsKmsKeyPair::new(
             &key,
@@ -128,7 +129,7 @@ mod tests {
         let signature = keypair.sign(&payload).expect("failed to sign");
         keypair
             .public()
-            .verify(KeyRole::Root, &payload, &signature)
+            .verify(KeyRole::Root, &payload, &signature, &signed_revocation_info)
             .expect("failed to verify");
     }
 

--- a/crates/criticaltrust/src/keys/pair_aws_kms.rs
+++ b/crates/criticaltrust/src/keys/pair_aws_kms.rs
@@ -106,6 +106,7 @@ mod tests {
     use rand_core::{OsRng, RngCore};
     use std::process::Command;
     use std::sync::Once;
+    use time::macros::datetime;
     use tokio::runtime::Runtime;
     // We want to have tests for all of criticaltrust, which makes testing the integration with AWS
     // KMS quite tricky. To make it work, the tests for this module spawn a Docker container for
@@ -115,7 +116,7 @@ mod tests {
     fn test_roundtrip() {
         let localstack = Localstack::init();
         let key = localstack.create_key(KeySpec::EccNistP256);
-        let signed_revocation_info = RevocationInfo::new();
+        let signed_revocation_info = RevocationInfo::new(datetime!(2025-01-01 0:00 UTC));
 
         let keypair = AwsKmsKeyPair::new(
             &key,

--- a/crates/criticaltrust/src/keys/pair_ephemeral.rs
+++ b/crates/criticaltrust/src/keys/pair_ephemeral.rs
@@ -5,6 +5,7 @@ use crate::keys::newtypes::{PayloadBytes, PrivateKeyBytes, SignatureBytes};
 use crate::keys::{KeyAlgorithm, KeyId, KeyPair, KeyRole, PublicKey};
 use crate::signatures::PublicKeysRepository;
 use crate::Error;
+use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 /// Pair of public and private keys generated at runtime and kept in memory.
@@ -12,6 +13,7 @@ use time::OffsetDateTime;
 /// There is intentionally no way to persist the private key of ephemeral key pairs, as that's
 /// considerably less secure than storing the key in a Hardware Security Module. Ephemeral key
 /// pairs are primarily meant to be used during automated testing.
+#[derive(Serialize, Deserialize)]
 pub struct EphemeralKeyPair {
     public: PublicKey,
     private: PrivateKeyBytes<'static>,

--- a/crates/criticaltrust/src/keys/pair_ephemeral.rs
+++ b/crates/criticaltrust/src/keys/pair_ephemeral.rs
@@ -13,7 +13,7 @@ use time::OffsetDateTime;
 /// There is intentionally no way to persist the private key of ephemeral key pairs, as that's
 /// considerably less secure than storing the key in a Hardware Security Module. Ephemeral key
 /// pairs are primarily meant to be used during automated testing.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct EphemeralKeyPair {
     public: PublicKey,
     private: PrivateKeyBytes<'static>,

--- a/crates/criticaltrust/src/keys/pair_ephemeral.rs
+++ b/crates/criticaltrust/src/keys/pair_ephemeral.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::keys::newtypes::{PayloadBytes, PrivateKeyBytes, SignatureBytes};
-use crate::keys::{KeyAlgorithm, KeyPair, KeyRole, PublicKey};
+use crate::keys::{KeyAlgorithm, KeyId, KeyPair, KeyRole, PublicKey};
+use crate::signatures::PublicKeysRepository;
 use crate::Error;
 use time::OffsetDateTime;
 
@@ -14,6 +15,12 @@ use time::OffsetDateTime;
 pub struct EphemeralKeyPair {
     public: PublicKey,
     private: PrivateKeyBytes<'static>,
+}
+
+impl PublicKeysRepository for EphemeralKeyPair {
+    fn get<'a>(&'a self, _id: &KeyId) -> Option<&'a PublicKey> {
+        Some(&self.public)
+    }
 }
 
 impl EphemeralKeyPair {

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -44,8 +44,14 @@ impl PublicKey {
             return Err(Error::SignaturesExpired);
         }
 
-        let hashed_payload =
-            String::from_utf8_lossy(hash_sha256(payload.as_bytes()).as_slice()).to_string();
+        let hashed_sha = hash_sha256(payload.as_bytes());
+        let mut hashed_payload = String::new();
+        for byte in hashed_sha {
+            // The bytes returned by Sha256 (in hashed_sha) are to be read as hex and are not to be
+            // confused with UTF-8 strings.
+            hashed_payload.push_str(&format!("{byte:X}"));
+        }
+
         if revocation_info
             .revoked_content_sha256
             .contains(&hashed_payload)

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -7,7 +7,7 @@ use crate::keys::KeyAlgorithm;
 use crate::revocation_info::RevocationInfo;
 use crate::sha256::hash_sha256;
 use crate::signatures::{PublicKeysRepository, Signable};
-use crate::Error;
+use crate::{Error, NoRevocationsCheck};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -99,6 +99,8 @@ impl PublicKey {
         self.role != KeyRole::Unknown && self.algorithm != KeyAlgorithm::Unknown
     }
 }
+
+impl NoRevocationsCheck for PublicKey {}
 
 impl PublicKeysRepository for PublicKey {
     fn get<'a>(&'a self, id: &KeyId) -> Option<&'a PublicKey> {

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -29,7 +29,7 @@ impl PublicKey {
     /// * The current key expired.
     /// * The signature doesn't match the payload.
     /// * The signature wasn't performed by the current key.
-    pub(crate) fn verify(
+    pub fn verify(
         &self,
         role: KeyRole,
         payload: &PayloadBytes<'_>,

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -47,7 +47,7 @@ impl PublicKey {
         let hashed_payload = hash_sha256(payload.as_bytes());
         if revocation_info
             .revoked_content_sha256
-            .contains(&hashed_payload.into())
+            .contains(&hashed_payload)
         {
             return Err(Error::ContentRevoked);
         }

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -27,6 +27,7 @@ impl PublicKey {
     /// revoked content does not match the payload.
     ///
     /// Signature verification could fail if:
+    /// * The Expiration date has passed.
     /// * The signature is present in the `RevocationInfo`.
     /// * The `RevocationInfo` cannot be verified.
     /// * [`verify_payload`](PublicKey::verify_without_revocations) fails.
@@ -49,12 +50,8 @@ impl PublicKey {
             return Err(Error::SignaturesExpired);
         }
 
-        let sha256_payload = match String::from_utf8(hash_sha256(payload.as_bytes())) {
-            Ok(sha) => sha,
-            Err(err) => return Err(Error::PayloadSha256CalcFailed(err)),
-        };
-
-        if revocation_info.revoked_content_sha256.contains(&sha256_payload) {
+        let s = String::from_utf8_lossy(hash_sha256(payload.as_bytes()).as_slice()).to_string();
+        if revocation_info.revoked_content_sha256.contains(&s) {
             return Err(Error::ContentRevoked);
         }
         self.verify_no_revocations_check(role, payload, signature)?;

--- a/crates/criticaltrust/src/keys/public.rs
+++ b/crates/criticaltrust/src/keys/public.rs
@@ -44,17 +44,10 @@ impl PublicKey {
             return Err(Error::SignaturesExpired);
         }
 
-        let hashed_sha = hash_sha256(payload.as_bytes());
-        let mut hashed_payload = String::new();
-        for byte in hashed_sha {
-            // The bytes returned by Sha256 (in hashed_sha) are to be read as hex and are not to be
-            // confused with UTF-8 strings.
-            hashed_payload.push_str(&format!("{byte:X}"));
-        }
-
+        let hashed_payload = hash_sha256(payload.as_bytes());
         if revocation_info
             .revoked_content_sha256
-            .contains(&hashed_payload)
+            .contains(&hashed_payload.into())
         {
             return Err(Error::ContentRevoked);
         }

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -14,10 +14,8 @@ mod sha256;
 pub mod signatures;
 
 pub mod revocation_info;
+
 #[cfg(test)]
 mod test_utils;
 
 pub use errors::Error;
-
-/// Trait to make sure that verification of only certain types does not check for revocation.
-pub trait NoRevocationsCheck {}

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+extern crate core;
+
 pub mod errors;
 pub mod integrity;
 pub mod keys;

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -15,3 +15,6 @@ pub mod signatures;
 mod test_utils;
 
 pub use errors::Error;
+
+/// Trait to make sure that verification of only certain types does not check for revocation.
+pub trait NoRevocationCheck {}

--- a/crates/criticaltrust/src/lib.rs
+++ b/crates/criticaltrust/src/lib.rs
@@ -11,10 +11,11 @@ mod serde_base64;
 mod sha256;
 pub mod signatures;
 
+pub mod revocation_info;
 #[cfg(test)]
 mod test_utils;
 
 pub use errors::Error;
 
 /// Trait to make sure that verification of only certain types does not check for revocation.
-pub trait NoRevocationCheck {}
+pub trait NoRevocationsCheck {}

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::keys::{KeyRole, PublicKey};
 use crate::signatures::{Signable, SignedPayload};
+use crate::NoRevocationCheck;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -159,6 +160,7 @@ pub struct PackageFile {
 
 // Revocations
 
+/// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RevocationInfo {
@@ -169,6 +171,11 @@ pub struct RevocationInfo {
 impl Signable for RevocationInfo {
     const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
 }
+
+/// Make sure verification of `RevocationInfo` type does no checks for revocations.
+///
+/// If we did, then this would be a circular logic and we say No! to such logic.
+impl NoRevocationCheck for RevocationInfo {}
 
 // Keys
 

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -6,11 +6,10 @@
 use std::path::PathBuf;
 
 use crate::keys::{KeyRole, PublicKey};
+use crate::revocation_info::RevocationInfo;
 use crate::signatures::{Signable, SignedPayload};
-use crate::NoRevocationCheck;
 use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 
 /// Typed representation of a manifest version number.
 ///
@@ -157,25 +156,6 @@ pub struct PackageFile {
     pub sha256: Vec<u8>,
     pub needs_proxy: bool,
 }
-
-// Revocations
-
-/// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct RevocationInfo {
-    pub revoked_content_sha256: Vec<String>,
-    pub expires_at: OffsetDateTime,
-}
-
-impl Signable for RevocationInfo {
-    const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
-}
-
-/// Make sure verification of `RevocationInfo` type does no checks for revocations.
-///
-/// If we did, then this would be a circular logic and we say No! to such logic.
-impl NoRevocationCheck for RevocationInfo {}
 
 // Keys
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -10,6 +10,7 @@ use time::OffsetDateTime;
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
+    // Incoming SHA256 data from the API is in the form of String, but we save each as a `Vec<u8>`.
     pub revoked_content_sha256: Vec<Vec<u8>>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -10,25 +10,13 @@ use time::OffsetDateTime;
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
-    pub revoked_content_sha256: Vec<RevocationContentSha256>,
+    pub revoked_content_sha256: Vec<Vec<u8>>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct RevocationContentSha256(#[serde(with = "crate::serde_base64")] Vec<u8>);
-
-impl From<Vec<u8>> for RevocationContentSha256 {
-    fn from(revoked_content_sha256: Vec<u8>) -> Self {
-        RevocationContentSha256(revoked_content_sha256)
-    }
-}
-
 impl RevocationInfo {
-    pub fn new(
-        revoked_content_sha256: Vec<RevocationContentSha256>,
-        expires_at: OffsetDateTime,
-    ) -> Self {
+    pub fn new(revoked_content_sha256: Vec<Vec<u8>>, expires_at: OffsetDateTime) -> Self {
         RevocationInfo {
             revoked_content_sha256,
             expires_at,
@@ -44,3 +32,15 @@ impl Signable for RevocationInfo {
 ///
 /// If we did, then this would be a circular logic and we say No! to such logic.
 impl NoRevocationsCheck for RevocationInfo {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    #[test]
+    fn debug_revocation_info() {
+        let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2025-08-05 00:00 UTC));
+        assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2025-08-05 0:00:00.0 +00:00:00 }", format!("{:?}", r));
+    }
+}

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -8,15 +8,22 @@ use time::OffsetDateTime;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
     pub revoked_content_sha256: Vec<String>,
+    #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
 }
 
-impl Default for RevocationInfo {
-    fn default() -> Self {
+impl RevocationInfo {
+    pub fn new() -> Self {
         RevocationInfo {
             revoked_content_sha256: Vec::new(),
             expires_at: OffsetDateTime::now_utc(),
         }
+    }
+}
+
+impl Default for RevocationInfo {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -5,7 +5,6 @@ use crate::keys::KeyRole;
 use crate::signatures::Signable;
 use crate::NoRevocationsCheck;
 use serde::{Deserialize, Serialize};
-use time::macros::datetime;
 use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
@@ -31,17 +30,17 @@ impl From<Vec<u8>> for RevocationContentSha256 {
 }
 
 impl RevocationInfo {
-    pub fn new() -> Self {
+    pub fn new(datetime: OffsetDateTime) -> Self {
         RevocationInfo {
             revoked_content_sha256: Vec::new(),
-            expires_at: datetime!(2025-01-01 0:00 UTC),
+            expires_at: datetime,
         }
     }
 }
 
 impl Default for RevocationInfo {
     fn default() -> Self {
-        Self::new()
+        Self::new(OffsetDateTime::now_utc())
     }
 }
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -1,0 +1,31 @@
+use crate::keys::KeyRole;
+use crate::signatures::Signable;
+use crate::NoRevocationsCheck;
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+
+/// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RevocationInfo {
+    pub revoked_content_sha256: Vec<String>,
+    pub expires_at: OffsetDateTime,
+}
+
+impl Default for RevocationInfo {
+    fn default() -> Self {
+        RevocationInfo {
+            revoked_content_sha256: Vec::new(),
+            expires_at: OffsetDateTime::now_utc(),
+        }
+    }
+}
+
+impl Signable for RevocationInfo {
+    const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
+}
+
+/// Make sure verification of `RevocationInfo` type does no checks for revocations.
+///
+/// If we did, then this would be a circular logic and we say No! to such logic.
+impl NoRevocationsCheck for RevocationInfo {}

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -11,9 +11,23 @@ use time::OffsetDateTime;
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
-    pub revoked_content_sha256: Vec<String>,
+    pub revoked_content_sha256: Vec<RevocationContentSha256>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct RevocationContentSha256 {
+    #[serde(with = "crate::serde_base64")]
+    pub revoked_content_sha256: Vec<u8>,
+}
+
+impl From<Vec<u8>> for RevocationContentSha256 {
+    fn from(revoked_content_sha256: Vec<u8>) -> Self {
+        RevocationContentSha256 {
+            revoked_content_sha256,
+        }
+    }
 }
 
 impl RevocationInfo {

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
 use crate::keys::KeyRole;
 use crate::signatures::Signable;
 use crate::NoRevocationsCheck;

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -6,7 +6,6 @@ use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
 pub struct RevocationInfo {
     pub revoked_content_sha256: Vec<String>,
     pub expires_at: OffsetDateTime,

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn new_revocation_info() {
-        let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2025-08-05 00:00 UTC));
-        assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2025-08-05 0:00:00.0 +00:00:00 }", format!("{:?}", r));
+        let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2400-10-10 00:00 UTC));
+        assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2400-10-10 0:00:00.0 +00:00:00 }", format!("{:?}", r));
     }
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -16,16 +16,11 @@ pub struct RevocationInfo {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct RevocationContentSha256 {
-    #[serde(with = "crate::serde_base64")]
-    pub revoked_content_sha256: Vec<u8>,
-}
+pub struct RevocationContentSha256(#[serde(with = "crate::serde_base64")] Vec<u8>);
 
 impl From<Vec<u8>> for RevocationContentSha256 {
     fn from(revoked_content_sha256: Vec<u8>) -> Self {
-        RevocationContentSha256 {
-            revoked_content_sha256,
-        }
+        RevocationContentSha256(revoked_content_sha256)
     }
 }
 

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -25,10 +25,13 @@ impl From<Vec<u8>> for RevocationContentSha256 {
 }
 
 impl RevocationInfo {
-    pub fn new(datetime: OffsetDateTime) -> Self {
+    pub fn new(
+        revoked_content_sha256: Vec<RevocationContentSha256>,
+        expires_at: OffsetDateTime,
+    ) -> Self {
         RevocationInfo {
-            revoked_content_sha256: Vec::new(),
-            expires_at: datetime,
+            revoked_content_sha256,
+            expires_at,
         }
     }
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -2,6 +2,7 @@ use crate::keys::KeyRole;
 use crate::signatures::Signable;
 use crate::NoRevocationsCheck;
 use serde::{Deserialize, Serialize};
+use time::macros::datetime;
 use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
@@ -16,7 +17,7 @@ impl RevocationInfo {
     pub fn new() -> Self {
         RevocationInfo {
             revoked_content_sha256: Vec::new(),
-            expires_at: OffsetDateTime::now_utc(),
+            expires_at: datetime!(2025-01-01 0:00 UTC),
         }
     }
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -3,14 +3,18 @@
 
 use crate::keys::KeyRole;
 use crate::signatures::Signable;
-use crate::NoRevocationsCheck;
 use serde::{Deserialize, Serialize};
+use serde_with::base64::Base64;
+use serde_with::serde_as;
 use time::OffsetDateTime;
 
 /// Holds hashes of revoked content which are included as a part of the [`KeysManifest`].
+#[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationInfo {
-    // Incoming SHA256 data from the API is in the form of String, but we save each as a `Vec<u8>`.
+    // Incoming SHA256 data from the API is in the form of Base64 encoded, but we save each
+    // as a `Vec<u8>`.
+    #[serde_as(as = "Vec<Base64>")]
     pub revoked_content_sha256: Vec<Vec<u8>>,
     #[serde(with = "time::serde::rfc3339")]
     pub expires_at: OffsetDateTime,
@@ -28,11 +32,6 @@ impl RevocationInfo {
 impl Signable for RevocationInfo {
     const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
 }
-
-/// Make sure verification of `RevocationInfo` type does no checks for revocations.
-///
-/// If we did, then this would be a circular logic and we say No! to such logic.
-impl NoRevocationsCheck for RevocationInfo {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -38,12 +38,6 @@ impl RevocationInfo {
     }
 }
 
-impl Default for RevocationInfo {
-    fn default() -> Self {
-        Self::new(OffsetDateTime::now_utc())
-    }
-}
-
 impl Signable for RevocationInfo {
     const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
 }

--- a/crates/criticaltrust/src/revocation_info.rs
+++ b/crates/criticaltrust/src/revocation_info.rs
@@ -40,7 +40,7 @@ mod tests {
     use time::macros::datetime;
 
     #[test]
-    fn debug_revocation_info() {
+    fn new_revocation_info() {
         let r = RevocationInfo::new(vec![vec![12, 21, 33]], datetime!(2025-08-05 00:00 UTC));
         assert_eq!("RevocationInfo { revoked_content_sha256: [[12, 21, 33]], expires_at: 2025-08-05 0:00:00.0 +00:00:00 }", format!("{:?}", r));
     }

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -209,17 +209,20 @@ mod tests {
     #[test]
     fn test_load_all_revoked_content_empty() {
         let root = generate_key(KeyRole::Root);
-        let revocation = generate_trusted_key(KeyRole::Revocation, &root);
+        let (revocation_keypair, signed_public_revocation_key) =
+            generate_trusted_key(KeyRole::Revocation, &root);
 
         let revoked_content = RevocationInfo::new(vec![], datetime!(2400-10-10 00:00 UTC));
         let mut signed_revoked_content = SignedPayload::new(&revoked_content).unwrap();
-        signed_revoked_content.add_signature(&revocation.0).unwrap();
+        signed_revoked_content
+            .add_signature(&revocation_keypair)
+            .unwrap();
 
         let mut keychain = Keychain::new(root.public()).unwrap();
 
         let keys_manifest = KeysManifest {
             version: ManifestVersion,
-            keys: vec![revocation.1],
+            keys: vec![signed_public_revocation_key],
             revoked_signatures: signed_revoked_content,
         };
 
@@ -235,19 +238,22 @@ mod tests {
     #[test]
     fn test_load_all_revoked_content_one_item() {
         let root = generate_key(KeyRole::Root);
-        let revocation = generate_trusted_key(KeyRole::Revocation, &root);
+        let (revocation_keypair, signed_public_revocation_key) =
+            generate_trusted_key(KeyRole::Revocation, &root);
         let revoked_content = RevocationInfo::new(
             vec![vec![1, 2, 3]],
             OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
         );
         let mut signed_revoked_content = SignedPayload::new(&revoked_content).unwrap();
-        signed_revoked_content.add_signature(&revocation.0).unwrap();
+        signed_revoked_content
+            .add_signature(&revocation_keypair)
+            .unwrap();
 
         let mut keychain = Keychain::new(root.public()).unwrap();
 
         let keys_manifest = KeysManifest {
             version: ManifestVersion,
-            keys: vec![revocation.1],
+            keys: vec![signed_public_revocation_key],
             revoked_signatures: signed_revoked_content,
         };
 

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -3,7 +3,7 @@
 
 use crate::keys::{KeyId, KeyRole, PublicKey};
 use crate::manifests::KeysManifest;
-use crate::revocation_info::RevocationInfo;
+use crate::revocation_info::{RevocationContentSha256, RevocationInfo};
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
 use std::collections::HashMap;
@@ -24,7 +24,10 @@ impl Keychain {
     pub fn new(trust_root: &PublicKey) -> Result<Self, Error> {
         let mut keychain = Self {
             keys: HashMap::new(),
-            revocation_info: RevocationInfo::new(datetime!(2025-01-01 0:00 UTC)),
+            revocation_info: RevocationInfo::new(
+                Vec::<RevocationContentSha256>::new(),
+                datetime!(2025-01-01 0:00 UTC),
+            ),
         };
 
         if trust_root.role != KeyRole::Root {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -44,9 +44,9 @@ impl Keychain {
         self.revocation_info.clone()
     }
 
-    /// Load the following into [`Keychain`] provided the [`KeysManifest`].
-    /// 1. All the verified keys.
-    /// 2. Revocation information from the revoked content.
+    /// Update the [`Keychain`] provided the [`KeysManifest`]:
+    /// 1. Verify and load all the verified keys.
+    /// 2. Verify and replace the Revocation information from the revoked content.
     pub fn load_all(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
         // Load all keys from KeysManifest.
         for key in &keys_manifest.keys {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_load_all_revoked_content_empty() {
-        // Test `load_all` method with RevocationInfo but empty list.
+        // Test `load_all` method with RevocationInfo being an empty list.
         let root = generate_key(KeyRole::Root);
         let revocation = generate_trusted_key(KeyRole::Revocation, &root);
 

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -201,9 +201,9 @@ mod tests {
         const SIGNED_BY_ROLE: KeyRole = KeyRole::Revocation;
     }
 
+    // Test `load_all` method with RevocationInfo being an empty list.
     #[test]
     fn test_load_all_revoked_content_empty() {
-        // Test `load_all` method with RevocationInfo being an empty list.
         let root = generate_key(KeyRole::Root);
         let revocation = generate_trusted_key(KeyRole::Revocation, &root);
 
@@ -226,10 +226,10 @@ mod tests {
         )
     }
 
+    // Test `load_all` method with RevocationInfo but with one item in the list. The call
+    // to `load_all` should not fail in verifying the revocation key.
     #[test]
     fn test_load_all_revoked_content_one_item() {
-        // Test `load_all` method with RevocationInfo but with one item in the list.
-        // The call to `load_all` should not fail in verifying the revocation key.
         let root = generate_key(KeyRole::Root);
         let revocation = generate_trusted_key(KeyRole::Revocation, &root);
         let revoked_content = RevocationInfo::new(

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -7,6 +7,7 @@ use crate::revocation_info::RevocationInfo;
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
 use std::collections::HashMap;
+use time::macros::datetime;
 
 /// Collection of all trusted public keys.
 pub struct Keychain {
@@ -23,7 +24,7 @@ impl Keychain {
     pub fn new(trust_root: &PublicKey) -> Result<Self, Error> {
         let mut keychain = Self {
             keys: HashMap::new(),
-            revocation_info: RevocationInfo::new(),
+            revocation_info: RevocationInfo::new(datetime!(2025-01-01 0:00 UTC)),
         };
 
         if trust_root.role != KeyRole::Root {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -23,7 +23,7 @@ impl Keychain {
     pub fn new(trust_root: &PublicKey) -> Result<Self, Error> {
         let mut keychain = Self {
             keys: HashMap::new(),
-            revocation_info: RevocationInfo::default(),
+            revocation_info: RevocationInfo::new(),
         };
 
         if trust_root.role != KeyRole::Root {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -40,8 +40,8 @@ impl Keychain {
         &self.keys
     }
 
-    pub fn revocation_info(&self) -> Option<RevocationInfo> {
-        self.revocation_info.clone()
+    pub fn revocation_info(&self) -> Option<&RevocationInfo> {
+        self.revocation_info.as_ref()
     }
 
     /// Update the [`Keychain`] provided the [`KeysManifest`]:

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -52,9 +52,7 @@ impl Keychain {
         }
 
         // Special case: verify and load only RevocationInfo.
-        let revocation_info = keys_manifest
-            .revoked_signatures
-            .get_verified_no_revocations_check(self)?;
+        let revocation_info = keys_manifest.revoked_signatures.get_verified(self)?;
         self.revocation_info = Some(revocation_info.clone());
 
         Ok(())
@@ -65,7 +63,7 @@ impl Keychain {
     /// The key has to be signed by either the root of trust or another key with the root role
     /// already part of the keychain.
     pub fn load(&mut self, key: &SignedPayload<PublicKey>) -> Result<KeyId, Error> {
-        let key = key.get_verified_no_revocations_check(self)?;
+        let key = key.get_verified(self)?;
         self.load_inner(&key)
     }
 

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -46,6 +46,9 @@ impl Keychain {
         &self.revocation_info
     }
 
+    /// Load the following into [`Keychain`] provided the [`KeysManifest`].
+    /// 1. All the verified keys.
+    /// 2. Revocation information from the revoked content.
     pub fn load_all(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
         // Load all keys from KeysManifest.
         for key in &keys_manifest.keys {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -45,14 +45,15 @@ impl Keychain {
     pub fn load_all(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
         // Load all keys from KeysManifest.
         for key in &keys_manifest.keys {
-            let a = self.load(key)?;
+            let _ = self.load(key)?;
         }
 
         // Special case: verify and load only RevocationInfo.
         let revocation_info = keys_manifest
             .revoked_signatures
-            .get_verified_no_revocations_check(self)?.clone();
-        self.revocation_info = revocation_info;
+            .get_verified_no_revocations_check(self)?;
+        self.revocation_info = revocation_info.clone();
+
         Ok(())
     }
 

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -5,6 +5,7 @@ use crate::keys::{KeyId, KeyRole, PublicKey};
 use crate::signatures::{PublicKeysRepository, SignedPayload};
 use crate::Error;
 use std::collections::HashMap;
+use crate::manifests::{KeysManifest, RevocationInfo};
 
 /// Collection of all trusted public keys.
 pub struct Keychain {
@@ -38,6 +39,14 @@ impl Keychain {
         let key = key.get_verified(self)?;
         self.load_inner(&key)
     }
+
+    // TODO change the name here from `lock_and_load` to something else.
+    pub fn load_with_revocation_check(&mut self, keys_manifest: &KeysManifest) -> Result<(), Error> {
+        let _ =
+
+        Ok(())
+    }
+
 
     fn load_inner(&mut self, key: &PublicKey) -> Result<KeyId, Error> {
         if !key.is_supported() {

--- a/crates/criticaltrust/src/signatures/keychain.rs
+++ b/crates/criticaltrust/src/signatures/keychain.rs
@@ -54,6 +54,9 @@ impl Keychain {
 
         // Load all keys from KeysManifest.
         for key in &keys_manifest.keys {
+            // Invalid keys are silently ignored, as they might be signed by a different root key
+            // used by a different release of criticalup, or they might be using an algorithm not
+            // supported by the current version of criticaltrust.
             let _ = self.load(key)?;
         }
 

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -3,10 +3,10 @@
 
 use crate::keys::newtypes::{PayloadBytes, SignatureBytes};
 use crate::keys::{KeyId, KeyPair, KeyRole, PublicKey};
+use crate::revocation_info::RevocationInfo;
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use std::cell::{Ref, RefCell};
-use crate::manifests::RevocationInfo;
 
 /// Piece of data with signatures attached to it.
 ///
@@ -43,7 +43,7 @@ impl<T: Signable> SignedPayload<T> {
         })
     }
 
-    /// Add a new signature to this signed paylaod, generated using the provided [`KeyPair`].
+    /// Add a new signature to this signed payload, generated using the provided [`KeyPair`].
     pub fn add_signature(&mut self, keypair: &dyn KeyPair) -> Result<(), Error> {
         self.signatures.push(Signature {
             key_sha256: keypair.public().calculate_id(),
@@ -58,33 +58,44 @@ impl<T: Signable> SignedPayload<T> {
     /// As signature verification and deserialization is expensive, it is only performed the first
     /// time the method is called. The cached results from the initial call will be returned in the
     /// rest of the cases.
-    // pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
-    //     let borrow = self.verified_deserialized.borrow();
-    //
-    //     if borrow.is_none() {
-    //         let value = verify_signature(
-    //             keys,
-    //             &self.signatures,
-    //             PayloadBytes::borrowed(self.signed.as_bytes()),
-    //         )?;
-    //
-    //         // In theory, `borrow_mut()` could panic if an immutable borrow was alive at the same
-    //         // time. In practice that won't happen, as we only populate the cache before returning
-    //         // any reference to the cached data.
-    //         drop(borrow);
-    //         *self.verified_deserialized.borrow_mut() = Some(value);
-    //     }
-    //
-    //     Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
-    //         b.as_ref().unwrap()
-    //     }))
-    // }
-
-    pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
+    pub fn get_verified(
+        &self,
+        keys: &dyn PublicKeysRepository,
+        revocation_info: &RevocationInfo,
+    ) -> Result<Ref<'_, T>, Error> {
         let borrow = self.verified_deserialized.borrow();
 
         if borrow.is_none() {
             let value = verify_signature(
+                keys,
+                &self.signatures,
+                PayloadBytes::borrowed(self.signed.as_bytes()),
+                revocation_info,
+            )?;
+
+            // In theory, `borrow_mut()` could panic if an immutable borrow was alive at the same
+            // time. In practice that won't happen, as we only populate the cache before returning
+            // any reference to the cached data.
+            drop(borrow);
+            *self.verified_deserialized.borrow_mut() = Some(value)
+        }
+
+        Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
+            b.as_ref().unwrap()
+        }))
+    }
+
+    /// Use this to verify only signed payloads that inherently do not require revocations checks.
+    /// Examples include Keys in the KeysManifest. Rest all should be checked with RevocationInfo
+    /// using get_verified.
+    pub fn get_verified_no_revocations_check(
+        &self,
+        keys: &dyn PublicKeysRepository,
+    ) -> Result<Ref<'_, T>, Error> {
+        let borrow = self.verified_deserialized.borrow();
+
+        if borrow.is_none() {
+            let value = verify_signature_no_revocations_check(
                 keys,
                 &self.signatures,
                 PayloadBytes::borrowed(self.signed.as_bytes()),
@@ -94,7 +105,7 @@ impl<T: Signable> SignedPayload<T> {
             // time. In practice that won't happen, as we only populate the cache before returning
             // any reference to the cached data.
             drop(borrow);
-            *self.verified_deserialized.borrow_mut() = Some(value);
+            *self.verified_deserialized.borrow_mut() = Some(value)
         }
 
         Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
@@ -108,11 +119,34 @@ impl<T: Signable> SignedPayload<T> {
     /// [`get_verified`](Self::get_verified) method), the cached deserialized payload will be
     /// returned. Otherwise, signature verification will be performed with the provided keychain
     /// before deserializing.
-    pub fn into_verified(self, keys: &dyn PublicKeysRepository) -> Result<T, Error> {
+    pub fn into_verified(
+        self,
+        keys: &dyn PublicKeysRepository,
+        revocation_info: &RevocationInfo,
+    ) -> Result<T, Error> {
         if let Some(deserialized) = self.verified_deserialized.into_inner() {
             Ok(deserialized)
         } else {
             verify_signature(
+                keys,
+                &self.signatures,
+                PayloadBytes::borrowed(self.signed.as_bytes()),
+                revocation_info,
+            )
+        }
+    }
+
+    /// Use this to verify only signed payloads that inherently do not require revocations checks.
+    /// Examples include Keys in the KeysManifest. Rest all should be checked with RevocationInfo
+    /// using into_verified.
+    pub fn into_verified_no_revocations_check(
+        self,
+        keys: &dyn PublicKeysRepository,
+    ) -> Result<T, Error> {
+        if let Some(deserialized) = self.verified_deserialized.into_inner() {
+            Ok(deserialized)
+        } else {
+            verify_signature_no_revocations_check(
                 keys,
                 &self.signatures,
                 PayloadBytes::borrowed(self.signed.as_bytes()),
@@ -125,6 +159,7 @@ fn verify_signature<T: Signable>(
     keys: &dyn PublicKeysRepository,
     signatures: &[Signature],
     signed: PayloadBytes<'_>,
+    revocation_info: &RevocationInfo,
 ) -> Result<T, Error> {
     for signature in signatures {
         let key = match keys.get(&signature.key_sha256) {
@@ -132,7 +167,37 @@ fn verify_signature<T: Signable>(
             None => continue,
         };
 
-        match key.verify(T::SIGNED_BY_ROLE, &signed, &signature.signature) {
+        match key.verify(
+            T::SIGNED_BY_ROLE,
+            &signed,
+            &signature.signature,
+            revocation_info,
+        ) {
+            Ok(()) => {}
+            Err(Error::VerificationFailed) => continue,
+            Err(other) => return Err(other),
+        }
+
+        // Deserialization is performed after the signature is verified, to ensure we are not
+        // deserializing malicious data.
+        return serde_json::from_slice(signed.as_bytes()).map_err(Error::DeserializationFailed);
+    }
+
+    Err(Error::VerificationFailed)
+}
+
+fn verify_signature_no_revocations_check<T: Signable>(
+    keys: &dyn PublicKeysRepository,
+    signatures: &[Signature],
+    signed: PayloadBytes<'_>,
+) -> Result<T, Error> {
+    for signature in signatures {
+        let key = match keys.get(&signature.key_sha256) {
+            Some(key) => key,
+            None => continue,
+        };
+
+        match key.verify_no_revocations_check(T::SIGNED_BY_ROLE, &signed, &signature.signature) {
             Ok(()) => {}
             Err(Error::VerificationFailed) => continue,
             Err(other) => return Err(other),
@@ -313,7 +378,10 @@ mod tests {
 
         assert_eq!(
             42,
-            payload.get_verified(test_env.keychain()).unwrap().answer
+            payload
+                .get_verified(test_env.keychain(), test_env.revocation_info())
+                .unwrap()
+                .answer
         );
 
         // If there was no caching, this method call would fail, as there is no valid key to
@@ -322,7 +390,10 @@ mod tests {
         assert_eq!(
             42,
             payload
-                .get_verified(TestEnvironment::prepare().keychain())
+                .get_verified(
+                    TestEnvironment::prepare().keychain(),
+                    test_env.revocation_info()
+                )
                 .unwrap()
                 .answer
         );
@@ -337,13 +408,13 @@ mod tests {
 
         let payload = prepare_payload(&[&key], r#"{"answer": 42"#);
         assert!(matches!(
-            payload.get_verified(test_env.keychain()),
+            payload.get_verified(test_env.keychain(), test_env.revocation_info()),
             Err(Error::DeserializationFailed(_))
         ));
 
         let payload = prepare_payload(&[&key], r#"{"answer": 42"#);
         assert!(matches!(
-            payload.into_verified(test_env.keychain()),
+            payload.into_verified(test_env.keychain(), test_env.revocation_info()),
             Err(Error::DeserializationFailed(_))
         ));
     }
@@ -389,7 +460,14 @@ mod tests {
             }"#,
         ).unwrap();
 
-        assert_eq!(42, payload.get_verified(&keychain).unwrap().answer);
+        let revocation_info = RevocationInfo::default();
+        assert_eq!(
+            42,
+            payload
+                .get_verified(&keychain, &revocation_info)
+                .unwrap()
+                .answer
+        );
     }
 
     // Utilities
@@ -400,7 +478,7 @@ mod tests {
         assert_eq!(
             42,
             get_payload
-                .get_verified(test_env.keychain())
+                .get_verified(test_env.keychain(), test_env.revocation_info())
                 .unwrap()
                 .answer
         );
@@ -410,7 +488,7 @@ mod tests {
         assert_eq!(
             42,
             into_payload
-                .into_verified(test_env.keychain())
+                .into_verified(test_env.keychain(), test_env.revocation_info())
                 .unwrap()
                 .answer
         );
@@ -420,14 +498,18 @@ mod tests {
     fn assert_verify_fail(test_env: &TestEnvironment, keys: &[&dyn KeyPair]) {
         let get_payload = prepare_payload(keys, SAMPLE_DATA);
         assert!(matches!(
-            get_payload.get_verified(test_env.keychain()).unwrap_err(),
+            get_payload
+                .get_verified(test_env.keychain(), test_env.revocation_info())
+                .unwrap_err(),
             Error::VerificationFailed
         ));
 
         // Two separate payloads are used to avoid caching.
         let into_payload = prepare_payload(keys, SAMPLE_DATA);
         assert!(matches!(
-            into_payload.into_verified(test_env.keychain()).unwrap_err(),
+            into_payload
+                .into_verified(test_env.keychain(), test_env.revocation_info())
+                .unwrap_err(),
             Error::VerificationFailed
         ));
     }

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -460,7 +460,7 @@ mod tests {
             }"#,
         ).unwrap();
 
-        let revocation_info = RevocationInfo::default();
+        let revocation_info = RevocationInfo::new();
         assert_eq!(
             42,
             payload

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -591,7 +591,7 @@ mod tests {
         // Since revocation info has a date that is long passed, the error is about expiration of signatures.
         assert!(matches!(
             s.get_verified(&keychain),
-            Err(Error::SignaturesExpired)
+            Err(Error::RevocationSignatureExpired(..))
         ));
     }
 

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -6,6 +6,7 @@ use crate::keys::{KeyId, KeyPair, KeyRole, PublicKey};
 use crate::Error;
 use serde::{Deserialize, Serialize};
 use std::cell::{Ref, RefCell};
+use crate::manifests::RevocationInfo;
 
 /// Piece of data with signatures attached to it.
 ///
@@ -57,6 +58,28 @@ impl<T: Signable> SignedPayload<T> {
     /// As signature verification and deserialization is expensive, it is only performed the first
     /// time the method is called. The cached results from the initial call will be returned in the
     /// rest of the cases.
+    // pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
+    //     let borrow = self.verified_deserialized.borrow();
+    //
+    //     if borrow.is_none() {
+    //         let value = verify_signature(
+    //             keys,
+    //             &self.signatures,
+    //             PayloadBytes::borrowed(self.signed.as_bytes()),
+    //         )?;
+    //
+    //         // In theory, `borrow_mut()` could panic if an immutable borrow was alive at the same
+    //         // time. In practice that won't happen, as we only populate the cache before returning
+    //         // any reference to the cached data.
+    //         drop(borrow);
+    //         *self.verified_deserialized.borrow_mut() = Some(value);
+    //     }
+    //
+    //     Ok(Ref::map(self.verified_deserialized.borrow(), |b| {
+    //         b.as_ref().unwrap()
+    //     }))
+    // }
+
     pub fn get_verified(&self, keys: &dyn PublicKeysRepository) -> Result<Ref<'_, T>, Error> {
         let borrow = self.verified_deserialized.borrow();
 

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -243,9 +243,11 @@ mod tests {
     use crate::manifests::{KeysManifest, ManifestVersion};
     use crate::signatures::Keychain;
     use crate::test_utils::{base64_encode, TestEnvironment};
-    use time::macros::datetime;
+    use time::{Duration, OffsetDateTime};
 
     const SAMPLE_DATA: &str = r#"{"answer":42}"#;
+    // Make sure there is enough number of days for expiration so tests don't need constant updates.
+    const EXPIRATION_EXTENSION_IN_DAYS: Duration = Duration::days(180);
 
     #[test]
     fn tets_verify_no_signatures() {
@@ -470,8 +472,10 @@ mod tests {
     fn test_verify_revocation_info() {
         let mut test_env = TestEnvironment::prepare();
         let key_revocation = test_env.create_key(KeyRole::Revocation);
-        let revoked_content =
-            RevocationInfo::new(vec![vec![1, 2, 3]], datetime!(2025-08-05 00:00 UTC));
+        let revoked_content = RevocationInfo::new(
+            vec![vec![1, 2, 3]],
+            OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
+        );
         let mut signed_revoked_content = SignedPayload::new(&revoked_content).unwrap();
         signed_revoked_content
             .add_signature(&key_revocation)
@@ -492,8 +496,10 @@ mod tests {
     fn test_verify_revocation_info_incorrect_keyrole() {
         let mut test_env = TestEnvironment::prepare();
         let key_not_revocation_role = test_env.create_key(KeyRole::Packages);
-        let revoked_content =
-            RevocationInfo::new(vec![vec![1, 2, 3]], datetime!(2025-08-05 00:00 UTC));
+        let revoked_content = RevocationInfo::new(
+            vec![vec![1, 2, 3]],
+            OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
+        );
         let mut signed_revoked_content = SignedPayload::new(&revoked_content).unwrap();
         signed_revoked_content
             .add_signature(&key_not_revocation_role)

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -188,7 +188,7 @@ fn verify_signature<T: Signable>(
     Err(Error::VerificationFailed)
 }
 
-fn verify_signature_no_revocations_check<T: Signable>(
+fn verify_signature_no_revocations_check<T: Signable + NoRevocationsCheck>(
     keys: &dyn PublicKeysRepository,
     signatures: &[Signature],
     signed: PayloadBytes<'_>,

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -462,11 +462,11 @@ mod tests {
             }"#,
         ).unwrap();
 
-        let revocation_info = RevocationInfo::new();
+        let revocation_info = keychain.revocation_info();
         assert_eq!(
             42,
             payload
-                .get_verified(&keychain, &revocation_info)
+                .get_verified(&keychain, revocation_info)
                 .unwrap()
                 .answer
         );

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -465,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Test will be fixed before merging"]
+    #[ignore = "Needs to be tested along with Install command"]
     fn verify_revoked_payload() {
         let mut keychain = Keychain::new(
             &serde_json::from_str(
@@ -530,7 +530,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Test will be fixed before merging"]
+    #[ignore = "Needs to be tested along with Install command"]
     fn verify_revoked_payload_expired_hashes() {
         let mut keychain = Keychain::new(
             &serde_json::from_str(

--- a/crates/criticaltrust/src/test_utils.rs
+++ b/crates/criticaltrust/src/test_utils.rs
@@ -45,10 +45,6 @@ impl TestEnvironment {
         &self.keychain
     }
 
-    pub(crate) fn revocation_info(&self) -> Option<RevocationInfo> {
-        self.keychain.revocation_info()
-    }
-
     pub(crate) fn create_untrusted_key(&self, role: KeyRole) -> EphemeralKeyPair {
         EphemeralKeyPair::generate(ALGORITHM, role, None).unwrap()
     }

--- a/crates/criticaltrust/src/test_utils.rs
+++ b/crates/criticaltrust/src/test_utils.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::keys::{EphemeralKeyPair, KeyAlgorithm, KeyPair, KeyRole, PublicKey};
+use crate::revocation_info::RevocationInfo;
 use crate::signatures::{Keychain, SignedPayload};
 use base64::Engine;
 use time::{Duration, OffsetDateTime};
@@ -17,12 +18,15 @@ impl TestEnvironment {
     pub(crate) fn prepare() -> Self {
         let root = EphemeralKeyPair::generate(ALGORITHM, KeyRole::Root, None).unwrap();
         let keychain = Keychain::new(root.public()).unwrap();
-
         Self { root, keychain }
     }
 
     pub(crate) fn keychain(&self) -> &Keychain {
         &self.keychain
+    }
+
+    pub(crate) fn revocation_info(&self) -> &RevocationInfo {
+        self.keychain.revocation_info()
     }
 
     pub(crate) fn create_untrusted_key(&self, role: KeyRole) -> EphemeralKeyPair {

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -30,6 +30,7 @@ xz2 = "0.1.7"
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+time = { version = "0.3.36", features = ["std", "serde", "serde-well-known", "macros"] }
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["filters"] }

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -182,7 +182,7 @@ fn check_for_revocation(
 ) -> Result<(), Error> {
     if time::OffsetDateTime::now_utc() >= revocation_info.expires_at {
         return Err(RevocationSignatureExpired(
-            criticaltrust::Error::RevocationSignatureExpired,
+            criticaltrust::Error::RevocationSignatureExpired(revocation_info.expires_at),
         ));
     }
 
@@ -200,8 +200,8 @@ fn check_for_revocation(
     for revoked_sha in &revocation_info.revoked_content_sha256 {
         if let Some(package) = base64_bytes_to_package_name.get(revoked_sha) {
             return Err(RevocationCheckFailed(
-                package.clone(),
-                criticaltrust::Error::ContentRevoked,
+                package.to_owned(),
+                criticaltrust::Error::ContentRevoked(package.to_owned()),
             ));
         }
     }

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use owo_colors::OwoColorize;
 
-use criticaltrust::integrity::IntegrityVerifier;
+use criticaltrust::integrity::{IntegrityError, IntegrityVerifier};
 use criticaltrust::manifests::{Release, ReleaseArtifactFormat};
 use criticalup_core::download_server_client::DownloadServerClient;
 use criticalup_core::project_manifest::{ProjectManifest, ProjectManifestProduct};
@@ -77,7 +77,9 @@ async fn install_product_afresh(
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
     let client = DownloadServerClient::new(&ctx.config, state);
     let keys = client.get_keys().await?;
-    let revocation_info = &keys.revocation_info();
+    let revocation_info = &keys
+        .revocation_info()
+        .ok_or_else(|| Error::MissingRevocationInfo(IntegrityError::MissingRevocationInfo))?;
 
     // TODO: Add tracing to support log levels, structured logging.
     println!(

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -77,6 +77,7 @@ async fn install_product_afresh(
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
     let client = DownloadServerClient::new(&ctx.config, state);
     let keys = client.get_keys().await?;
+    let revocation_info = keys.revocation_info();
 
     // TODO: Add tracing to support log levels, structured logging.
     println!(
@@ -90,7 +91,9 @@ async fn install_product_afresh(
     let release_manifest_from_server = client
         .get_product_release_manifest(product_name, product.release())
         .await?;
-    let verified_release_manifest = release_manifest_from_server.signed.into_verified(&keys)?;
+    let verified_release_manifest = release_manifest_from_server
+        .signed
+        .into_verified(&keys, revocation_info)?;
 
     // criticalup 0.1, return error if any of package.dependencies is not empty.
     // We have to use manifest's Release because the information about dependencies

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -77,7 +77,7 @@ async fn install_product_afresh(
     let abs_installation_dir_path = installation_dir.join(product.installation_id());
     let client = DownloadServerClient::new(&ctx.config, state);
     let keys = client.get_keys().await?;
-    let revocation_info = keys.revocation_info();
+    let revocation_info = &keys.revocation_info();
 
     // TODO: Add tracing to support log levels, structured logging.
     println!(

--- a/crates/criticalup-cli/src/commands/install.rs
+++ b/crates/criticalup-cli/src/commands/install.rs
@@ -180,7 +180,7 @@ fn check_for_revocation(
     revocation_info: &RevocationInfo,
     verified_release_manifest: &Release,
 ) -> Result<(), Error> {
-    if time::OffsetDateTime::now_utc() <= revocation_info.expires_at {
+    if time::OffsetDateTime::now_utc() >= revocation_info.expires_at {
         return Err(RevocationSignatureExpired(
             criticaltrust::Error::RevocationSignatureExpired,
         ));

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -42,6 +42,9 @@ pub(crate) enum Error {
     )]
     IntegrityErrorsWhileInstallation(Vec<IntegrityError>),
 
+    #[error(transparent)]
+    MissingRevocationInfo(#[from] IntegrityError),
+
     #[error("arg0 is not encoded in UTF-8")]
     NonUtf8Arg0,
     #[error("failed to invoke proxied command {}", .0.display())]

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -103,6 +103,8 @@ pub(crate) enum Error {
         tracing_subscriber::util::TryInitError,
     ),
 
+    #[error("failed to run install")]
+    RevocationSignatureExpired(#[source] criticaltrust::Error),
     #[error("failed to install package '{}' because it has been revoked", .0)]
     RevocationCheckFailed(String, #[source] criticaltrust::Error),
 

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -103,9 +103,9 @@ pub(crate) enum Error {
         tracing_subscriber::util::TryInitError,
     ),
 
-    #[error("failed to run install")]
+    #[error("failed to run install command")]
     RevocationSignatureExpired(#[source] criticaltrust::Error),
-    #[error("failed to install package '{}' because it has been revoked", .0)]
+    #[error("failed to install package '{}'", .0)]
     RevocationCheckFailed(String, #[source] criticaltrust::Error),
 
     #[cfg(windows)]

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -82,6 +82,9 @@ pub(crate) enum Error {
         kind: std::io::Error,
     },
 
+    #[error("failed to install package '{}' because it has been revoked", .0)]
+    RevocationCheckFailed(String, #[source] criticaltrust::Error),
+
     #[cfg(windows)]
     #[error("Could not set Ctrl-C handler.")]
     CtrlHandler,

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::config::Config;
+use crate::errors::Error::KeychainLoadingFailed;
 use crate::errors::{DownloadServerError, Error};
 use crate::state::State;
 use criticaltrust::keys::PublicKey;
@@ -57,7 +58,10 @@ impl DownloadServerClient {
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
         let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
-        let _ = keychain.load_all(&resp);
+        match keychain.load_all(&resp) {
+            Ok(_) => {}
+            Err(e) => return Err(KeychainLoadingFailed(e)),
+        }
         Ok(keychain)
     }
 

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -53,10 +53,10 @@ impl DownloadServerClient {
     }
 
     pub async fn get_keys(&self) -> Result<Keychain, Error> {
-        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
         let resp: KeysManifest = self
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
+        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
         let _ = keychain.load_all(&resp);
         Ok(keychain)
     }

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -57,15 +57,7 @@ impl DownloadServerClient {
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
         let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
-        // TODO: actually capture the `KeysManifest::revoked_signatures` from the response.
-        let _ = keychain.load_with_revocation_check(&resp);
-        // for key in &resp.keys {
-        //     // Invalid keys are silently ignored, as they might be signed by a different root key
-        //     // used by a different release of criticalup, or they might be using an algorithm not
-        //     // supported by the current version of criticaltrust.
-        //     let _ = keychain.lock_and_load();
-        // }
-
+        let _ = keychain.load_all(&resp);
         Ok(keychain)
     }
 

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -53,17 +53,18 @@ impl DownloadServerClient {
     }
 
     pub async fn get_keys(&self) -> Result<Keychain, Error> {
-        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
-
         let resp: KeysManifest = self
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
             .await?;
-        for key in &resp.keys {
-            // Invalid keys are silently ignored, as they might be signed by a different root key
-            // used by a different release of criticalup, or they might be using an algorithm not
-            // supported by the current version of criticaltrust.
-            let _ = keychain.load(key);
-        }
+        let mut keychain = Keychain::new(&self.trust_root).map_err(Error::KeychainInitFailed)?;
+        // TODO: actually capture the `KeysManifest::revoked_signatures` from the response.
+        let _ = keychain.load_with_revocation_check(&resp);
+        // for key in &resp.keys {
+        //     // Invalid keys are silently ignored, as they might be signed by a different root key
+        //     // used by a different release of criticalup, or they might be using an algorithm not
+        //     // supported by the current version of criticaltrust.
+        //     let _ = keychain.lock_and_load();
+        // }
 
         Ok(keychain)
     }

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -74,6 +74,9 @@ pub enum Error {
         #[source]
         kind: std::io::Error,
     },
+
+    #[error("failed to load keys into keychain")]
+    KeychainLoadingFailed(#[source] criticaltrust::Error),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/mock-download-server/src/handlers.rs
+++ b/crates/mock-download-server/src/handlers.rs
@@ -4,9 +4,6 @@
 use crate::Serialize;
 use crate::{AuthenticationToken, Data};
 use criticaltrust::manifests::ManifestVersion;
-use criticaltrust::revocation_info::RevocationInfo;
-use criticaltrust::signatures::SignedPayload;
-use time::{Duration, OffsetDateTime};
 use tiny_http::{Header, Method, Request, Response, ResponseBox, StatusCode};
 
 pub(crate) fn handle_request(data: &Data, req: &Request) -> ResponseBox {
@@ -42,11 +39,7 @@ fn handle_v1_keys(data: &Data) -> Result<Resp, Resp> {
     Ok(Resp::json(&criticaltrust::manifests::KeysManifest {
         version: ManifestVersion,
         keys: data.keys.clone(),
-        revoked_signatures: SignedPayload::new(&RevocationInfo {
-            revoked_content_sha256: Vec::new(),
-            expires_at: OffsetDateTime::now_utc() + Duration::days(99),
-        })
-        .unwrap(),
+        revoked_signatures: data.revoked_signatures.clone(),
     }))
 }
 

--- a/crates/mock-download-server/src/handlers.rs
+++ b/crates/mock-download-server/src/handlers.rs
@@ -3,7 +3,8 @@
 
 use crate::Serialize;
 use crate::{AuthenticationToken, Data};
-use criticaltrust::manifests::{ManifestVersion, RevocationInfo};
+use criticaltrust::manifests::ManifestVersion;
+use criticaltrust::revocation_info::RevocationInfo;
 use criticaltrust::signatures::SignedPayload;
 use time::{Duration, OffsetDateTime};
 use tiny_http::{Header, Method, Request, Response, ResponseBox, StatusCode};

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -6,7 +6,8 @@ mod server;
 
 pub use crate::server::MockServer;
 use criticaltrust::keys::PublicKey;
-use criticaltrust::manifests::{ReleaseManifest, RevocationInfo};
+use criticaltrust::manifests::ReleaseManifest;
+use criticaltrust::revocation_info::RevocationInfo;
 use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -12,7 +12,10 @@ use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use time::macros::datetime;
+use time::{Duration, OffsetDateTime};
+
+// Make sure there is enough number of days for expiration so tests don't need constant updates.
+const EXPIRATION_EXTENSION_IN_DAYS: Duration = Duration::days(180);
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -36,7 +39,7 @@ pub fn new() -> Builder {
             keys: Vec::new(),
             revoked_signatures: SignedPayload::new(&RevocationInfo::new(
                 Vec::new(),
-                datetime!(3025-01-01 0:00 UTC),
+                OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
             ))
             .unwrap(),
             release_manifests: HashMap::new(),

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -36,7 +36,7 @@ pub fn new() -> Builder {
             keys: Vec::new(),
             revoked_signatures: SignedPayload::new(&RevocationInfo::new(
                 Vec::new(),
-                datetime!(2025-01-01 0:00 UTC),
+                datetime!(3025-01-01 0:00 UTC),
             ))
             .unwrap(),
             release_manifests: HashMap::new(),

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -12,6 +12,7 @@ use criticaltrust::signatures::SignedPayload;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use time::macros::datetime;
 
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -33,7 +34,10 @@ pub fn new() -> Builder {
         data: Data {
             tokens: HashMap::new(),
             keys: Vec::new(),
-            revoked_signatures: SignedPayload::new(&RevocationInfo::new()).unwrap(),
+            revoked_signatures: SignedPayload::new(&RevocationInfo::new(
+                datetime!(2025-01-01 0:00 UTC),
+            ))
+            .unwrap(),
             release_manifests: HashMap::new(),
         },
     }

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -35,6 +35,7 @@ pub fn new() -> Builder {
             tokens: HashMap::new(),
             keys: Vec::new(),
             revoked_signatures: SignedPayload::new(&RevocationInfo::new(
+                Vec::new(),
                 datetime!(2025-01-01 0:00 UTC),
             ))
             .unwrap(),


### PR DESCRIPTION
This is the client-side implementation of checking package's hash revocation. 

To test this, you need to [edit the `get_keys` function](https://github.com/ferrocene/criticalup/blob/amanjeev/hash-call-on-site/crates/criticalup-core/src/download_server_client.rs#L56-L63) and hard code `KeysManifest`. Ask @amanjeev for that replacement.

Your `criticalup.toml` needs to be:

```toml
manifest-version = 1

[products.ferrocene]
release = "nightly-2024-05-23"
packages = [
    "rustc-x86_64-unknown-linux-gnu"
]
```

Run:

```sh
cargo run --package criticalup-dev install --project /path/to/critical.toml
```

You should see an error about content revocation and `install` command failing.


This PR supersedes #38.