### PR TITLE
Verify command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 - Standardized error messages as close to English rules as possible.
 - Changed several CriticalTrust APIs to be async.
+- Added a `criticalup verify` command that can be used to verify that a locally installed toolchain
+  is not corrupted or tampered with.
 
 ## [1.1.0] - 2024-08-28
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "clap",
  "criticaltrust",
  "criticalup-core",
+ "futures",
  "insta",
  "mock-download-server",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
  "winapi",
  "windows-sys 0.52.0",
  "xz2",
@@ -2242,6 +2243,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +2911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3060,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["docs/.linkchecker/src/tools/linkchecker"]
 default-members = ["crates/criticalup"]
 
 [workspace.dependencies]
+futures = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "process"] }
 reqwest = { version = "0.12.4", default-features = false, features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
   "env-filter",
   "json",
 ] }
+walkdir = "2"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -31,6 +31,7 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 time = { version = "0.3.36", features = ["std", "serde", "serde-well-known", "macros"] }
+walkdir.workspace = true
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["filters"] }

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -22,6 +22,7 @@ atty = "0.2.14"
 clap = { version = "4.5.4", features = ["std", "derive", "help", "usage"] }
 criticaltrust = { path = "../criticaltrust" }
 criticalup-core = { path = "../criticalup-core" }
+futures.workspace = true
 owo-colors = { version = "4.0.0", default-features = false, features = ["supports-colors"] }
 serde_json = "1.0.117"
 tar = "0.4.40"

--- a/crates/criticalup-cli/src/commands/mod.rs
+++ b/crates/criticalup-cli/src/commands/mod.rs
@@ -8,5 +8,5 @@ pub(crate) mod clean;
 pub(crate) mod install;
 pub(crate) mod remove;
 pub(crate) mod run;
-pub(crate) mod which;
 pub(crate) mod verify;
+pub(crate) mod which;

--- a/crates/criticalup-cli/src/commands/mod.rs
+++ b/crates/criticalup-cli/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod install;
 pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod which;
+pub(crate) mod verify;

--- a/crates/criticalup-cli/src/commands/verify.rs
+++ b/crates/criticalup-cli/src/commands/verify.rs
@@ -50,7 +50,7 @@ pub(crate) async fn run(
 
     let installation_dir = &ctx.config.paths.installation_dir;
 
-    verify(&keys, &installation_dir, &project_manifest).await
+    verify(&keys, installation_dir, &project_manifest).await
 }
 
 async fn verify(
@@ -65,7 +65,10 @@ async fn verify(
     for product in project_manifest.products() {
         working_set.push(verify_product(keys, installation_dir, product));
     }
-    futures::future::join_all(working_set).await.into_iter().collect::<Result<(), Error>>()?;
+    futures::future::join_all(working_set)
+        .await
+        .into_iter()
+        .collect::<Result<(), Error>>()?;
 
     Ok(())
 }

--- a/crates/criticalup-cli/src/commands/verify.rs
+++ b/crates/criticalup-cli/src/commands/verify.rs
@@ -20,7 +20,7 @@ use walkdir::WalkDir;
 
 use crate::{errors::Error, Context};
 
-#[tracing::instrument(level = "debug", skip_all, fields(project))]
+#[tracing::instrument(level = "debug", skip_all, fields(manifest_path))]
 pub(crate) async fn run(
     ctx: &Context,
     manifest_path: Option<PathBuf>,

--- a/crates/criticalup-cli/src/commands/verify.rs
+++ b/crates/criticalup-cli/src/commands/verify.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{env::current_dir, os::unix::fs::MetadataExt, path::{Path, PathBuf}};
+
+use criticaltrust::{integrity::IntegrityVerifier, signatures::Keychain};
+use criticalup_core::{download_server_cache::DownloadServerCache, download_server_client::DownloadServerClient, project_manifest::{ProjectManifest, ProjectManifestProduct}, state::State};
+use tracing::Span;
+use walkdir::WalkDir;
+
+use crate::{errors::Error, Context};
+
+#[tracing::instrument(level = "debug", skip_all, fields(project))]
+pub(crate) async fn run(
+    ctx: &Context,
+    manifest_path: Option<PathBuf>,
+    offline: bool,
+) -> Result<(), Error> {
+    let span = Span::current();
+    let manifest_path = if let Some(manifest_path) = manifest_path {
+        manifest_path
+    } else {
+        ProjectManifest::discover(&current_dir()?)?
+    };
+    span.record("manifest_path", tracing::field::display(manifest_path.display()));
+
+    let state = State::load(&ctx.config).await?;
+    let maybe_client = if !offline {
+        Some(DownloadServerClient::new(&ctx.config, &state))
+    } else {
+        None
+    };
+    let cache = DownloadServerCache::new(&ctx.config.paths.cache_dir, &maybe_client).await?;
+    let keys = cache.keys().await?;
+
+    let project_manifest = ProjectManifest::load(&manifest_path)?;
+    
+    let installation_dir = &ctx.config.paths.installation_dir;
+
+    for product in project_manifest.products() {
+        verify_product(&keys, installation_dir, product).await?;
+    }
+
+    Ok(())
+}
+
+#[tracing::instrument(level = "debug", skip_all, fields(product_path))]
+async fn verify_product(
+    keys: &Keychain,
+    installation_dir: &Path,
+    product: &ProjectManifestProduct,
+) -> Result<(), Error> {
+    let span = Span::current();
+
+    let mut integrity_verifier = IntegrityVerifier::new(&keys);
+
+    let product_name = product.name();
+    let product_path = installation_dir.join(product.installation_id());
+    span.record("product_path", tracing::field::display(product_path.display()));
+
+    tracing::info!("Verifying project `{product_name}`");
+
+    for entry in WalkDir::new(product_path) {
+        let entry = entry?;
+        
+        if entry.file_type().is_file() {
+            tracing::trace!("Adding {}", tracing::field::display(entry.path().display()));
+            integrity_verifier.add(
+                &entry.path(),
+                entry.metadata()?.mode(),
+                &tokio::fs::read(&entry.path()).await?,
+            );
+        }
+    }
+
+    integrity_verifier
+        .verify()
+        .map_err(Error::IntegrityErrorsWhileVerifying)?;
+
+    tracing::info!("Successfully verified `{product_name}`");
+
+    Ok(())
+}

--- a/crates/criticalup-cli/src/commands/verify.rs
+++ b/crates/criticalup-cli/src/commands/verify.rs
@@ -73,7 +73,7 @@ async fn verify_product(
         tracing::field::display(product_path.display()),
     );
 
-    tracing::info!("Verifying project `{product_name}`");
+    tracing::info!("Verifying product '{product_name}'");
 
     for entry in WalkDir::new(product_path) {
         let entry = entry?;

--- a/crates/criticalup-cli/src/commands/verify.rs
+++ b/crates/criticalup-cli/src/commands/verify.rs
@@ -92,7 +92,7 @@ async fn verify_product(
         .verify()
         .map_err(Error::IntegrityErrorsWhileVerifying)?;
 
-    tracing::info!("Successfully verified `{product_name}`");
+    tracing::info!("Successfully verified '{product_name}'");
 
     Ok(())
 }

--- a/crates/criticalup-cli/src/commands/verify.rs
+++ b/crates/criticalup-cli/src/commands/verify.rs
@@ -20,7 +20,7 @@ use walkdir::WalkDir;
 
 use crate::{errors::Error, Context};
 
-#[tracing::instrument(level = "debug", skip_all, fields(manifest_path))]
+#[tracing::instrument(level = "debug", skip_all, fields(manifest_path, %offline))]
 pub(crate) async fn run(
     ctx: &Context,
     manifest_path: Option<PathBuf>,

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -5,9 +5,9 @@ use criticaltrust::integrity::IntegrityError;
 pub(crate) use criticaltrust::Error as TrustError;
 pub(crate) use criticalup_core::errors::BinaryProxyUpdateError;
 pub(crate) use criticalup_core::errors::Error as LibError;
-use tokio::task::JoinError;
 use std::path::PathBuf;
 use std::string::FromUtf8Error as Utf8Error;
+use tokio::task::JoinError;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -5,6 +5,7 @@ use criticaltrust::integrity::IntegrityError;
 pub(crate) use criticaltrust::Error as TrustError;
 pub(crate) use criticalup_core::errors::BinaryProxyUpdateError;
 pub(crate) use criticalup_core::errors::Error as LibError;
+use tokio::task::JoinError;
 use std::path::PathBuf;
 use std::string::FromUtf8Error as Utf8Error;
 
@@ -20,6 +21,8 @@ pub(crate) enum Error {
     Utf8(#[from] Utf8Error),
     #[error(transparent)]
     WalkDir(#[from] walkdir::Error),
+    #[error(transparent)]
+    Join(#[from] JoinError),
 
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -18,6 +18,8 @@ pub(crate) enum Error {
     Trust(#[from] TrustError),
     #[error(transparent)]
     Utf8(#[from] Utf8Error),
+    #[error(transparent)]
+    WalkDir(#[from] walkdir::Error),
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -41,6 +43,13 @@ pub(crate) enum Error {
       .0.iter().map(|err| { err.to_string() }).collect::<Vec<_>>().join("\n")
     )]
     IntegrityErrorsWhileInstallation(Vec<IntegrityError>),
+
+    #[error("Some files did not pass the integrity checks during verification.\n \
+        Please clean your installation directory and re-install the project again.\n \
+        The following errors were found:\n\n{}",
+        .0.iter().map(|err| { err.to_string() }).collect::<Vec<_>>().join("\n")
+    )]
+    IntegrityErrorsWhileVerifying(Vec<IntegrityError>),
 
     #[error(transparent)]
     MissingRevocationInfo(#[from] IntegrityError),

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -63,10 +63,9 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
         Commands::Clean => commands::clean::run(&ctx).await?,
         Commands::Remove { project } => commands::remove::run(&ctx, project).await?,
         Commands::Run { command, project } => commands::run::run(&ctx, command, project).await?,
-        Commands::Verify {
-            project,
-            offline,
-        } => commands::verify::run(&ctx, project, offline).await?,
+        Commands::Verify { project, offline } => {
+            commands::verify::run(&ctx, project, offline).await?
+        }
         Commands::Which {
             binary: tool,
             project,
@@ -173,7 +172,7 @@ enum Commands {
         /// Don't download from the server, only use previously cached artifacts
         #[arg(long)]
         offline: bool,
-        
+
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -63,6 +63,10 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
         Commands::Clean => commands::clean::run(&ctx).await?,
         Commands::Remove { project } => commands::remove::run(&ctx, project).await?,
         Commands::Run { command, project } => commands::run::run(&ctx, command, project).await?,
+        Commands::Verify {
+            project,
+            offline,
+        } => commands::verify::run(&ctx, project, offline).await?,
         Commands::Which {
             binary: tool,
             project,
@@ -159,6 +163,17 @@ enum Commands {
 
     /// Delete all the products specified in the manifest `criticalup.toml`
     Remove {
+        /// Path to the manifest `criticalup.toml`
+        #[arg(long)]
+        project: Option<PathBuf>,
+    },
+
+    /// Verify a given toolchain
+    Verify {
+        /// Don't download from the server, only use previously cached artifacts
+        #[arg(long)]
+        offline: bool,
+        
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,

--- a/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
@@ -19,6 +19,7 @@ Commands:
   clean    Delete all unused and untracked installations
   run      Run a command for a given toolchain
   remove   Delete all the products specified in the manifest `criticalup.toml`
+  verify   Verify a given toolchain
   which    Display which binary will be run for a given command
 
 Options:

--- a/docs/src/using-criticalup/toolchain-management.rst
+++ b/docs/src/using-criticalup/toolchain-management.rst
@@ -108,3 +108,15 @@ much disk space the ``clean`` command can help by deleting unused toolchains.
 .. code-block::
 
    criticalup clean
+
+Verifying Toolchains
+^^^^^^^^^^^^^^^^^^^^
+
+If a toolchain is suspected to be corrupted or tampered with, the verification
+step performed during installation can be repeated.
+
+From the direcory containing the relevant ``criticalup.toml``:
+
+.. code-block::
+
+   criticalup verify


### PR DESCRIPTION
Completes https://ferroussystems.clickup.com/t/86941z3t2

To test, run `criticalup verify` in an applicable folder. Mostly based off @amanjeev 's `install` code.

You can pass `-vvvvvv` (with however number of `v`s makes you happy) and see the tracing output of files being added to the validator.
