### PR TITLE
Add archive command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - Changed several CriticalTrust APIs to be async.
 - Added a `criticalup verify` command that can be used to verify that a locally installed toolchain
   is not corrupted or tampered with.
-- Added `criticalup tarball` which creates an archive of the toolchain for cold storage or backup.
+- Added `criticalup archive` which creates an archive of the toolchain for cold storage or backup.
 
 ## [1.1.0] - 2024-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Changed several CriticalTrust APIs to be async.
 - Added a `criticalup verify` command that can be used to verify that a locally installed toolchain
   is not corrupted or tampered with.
+- Added `criticalup tarball` which creates an archive of the toolchain for cold storage or backup.
 
 ## [1.1.0] - 2024-08-28
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-members = ["crates/criticalup"]
 
 [workspace.dependencies]
 futures = "0.3"
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "process"] }
 reqwest = { version = "0.12.8", default-features = false, features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.3"

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0.117"
 tar = "0.4.40"
 thiserror = "1.0.61"
 xz2 = "0.1.7"
+tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -37,7 +38,7 @@ walkdir.workspace = true
 insta = { version = "1.39.0", features = ["filters"] }
 mock-download-server = { path = "../mock-download-server" }
 serde = { version = "1.0.203", features = ["derive"] }
-tempfile = "3.10.1"
+tempfile.workspace = true
 regex = "1.10.4"
 
 [target.x86_64-pc-windows-msvc.dependencies]

--- a/crates/criticalup-cli/src/commands/archive.rs
+++ b/crates/criticalup-cli/src/commands/archive.rs
@@ -53,13 +53,13 @@ pub(crate) async fn run(
 
     let project_manifest = ProjectManifest::load(&manifest_path)?;
 
-    tarball(cache, &keys, &project_manifest, out).await?;
+    archive(cache, &keys, &project_manifest, out).await?;
 
     Ok(())
 }
 
 #[tracing::instrument(level = "debug", skip_all, fields(product_path))]
-async fn tarball(
+async fn archive(
     cache: DownloadServerCache<'_>,
     keys: &Keychain,
     project_manifest: &ProjectManifest,

--- a/crates/criticalup-cli/src/commands/archive.rs
+++ b/crates/criticalup-cli/src/commands/archive.rs
@@ -125,7 +125,7 @@ async fn archive(
     }
     integrity_verifier
         .verify()
-        .map_err(Error::IntegrityErrorsWhileTarballing)?;
+        .map_err(Error::IntegrityErrorsWhileArchiving)?;
     tracing::info!("Verified toolchain");
 
     // Wrap it up.

--- a/crates/criticalup-cli/src/commands/archive.rs
+++ b/crates/criticalup-cli/src/commands/archive.rs
@@ -65,7 +65,7 @@ async fn archive(
     project_manifest: &ProjectManifest,
     out: Option<&PathBuf>,
 ) -> Result<(), Error> {
-    // Path to installables we will include in the tarball
+    // Path to installables we will include in the archive
     // Note: Do not try to get clever and parallize the building of this, download
     //       bandwidth is not generous for many people.
     let mut installables = vec![];

--- a/crates/criticalup-cli/src/commands/mod.rs
+++ b/crates/criticalup-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+pub(crate) mod archive;
 pub(crate) mod auth;
 pub(crate) mod auth_remove;
 pub(crate) mod auth_set;
@@ -9,5 +10,4 @@ pub(crate) mod install;
 pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod verify;
-pub(crate) mod archive;
 pub(crate) mod which;

--- a/crates/criticalup-cli/src/commands/mod.rs
+++ b/crates/criticalup-cli/src/commands/mod.rs
@@ -9,5 +9,5 @@ pub(crate) mod install;
 pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod verify;
-pub(crate) mod which;
 pub(crate) mod tarball;
+pub(crate) mod which;

--- a/crates/criticalup-cli/src/commands/mod.rs
+++ b/crates/criticalup-cli/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod verify;
 pub(crate) mod which;
+pub(crate) mod tarball;

--- a/crates/criticalup-cli/src/commands/mod.rs
+++ b/crates/criticalup-cli/src/commands/mod.rs
@@ -9,5 +9,5 @@ pub(crate) mod install;
 pub(crate) mod remove;
 pub(crate) mod run;
 pub(crate) mod verify;
-pub(crate) mod tarball;
+pub(crate) mod archive;
 pub(crate) mod which;

--- a/crates/criticalup-cli/src/commands/tarball.rs
+++ b/crates/criticalup-cli/src/commands/tarball.rs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use core::arch;
+#[cfg(not(windows))]
+use std::os::unix::fs::MetadataExt;
+use std::{
+    env::current_dir, fs::OpenOptions, io::Write, path::{Path, PathBuf}
+};
+
+use criticaltrust::{integrity::IntegrityVerifier, signatures::Keychain};
+use criticalup_core::{
+    download_server_cache::DownloadServerCache,
+    download_server_client::DownloadServerClient,
+    project_manifest::{ProjectManifest, ProjectManifestProduct},
+    state::State,
+};
+use tempfile::TempDir;
+use tokio::task::spawn_blocking;
+use tracing::Span;
+use walkdir::WalkDir;
+
+use crate::{errors::Error, Context};
+
+use super::install::DEFAULT_RELEASE_ARTIFACT_FORMAT;
+
+#[tracing::instrument(level = "debug", skip_all, fields(manifest_path, %offline))]
+pub(crate) async fn run(
+    ctx: &Context,
+    manifest_path: Option<&PathBuf>,
+    offline: bool,
+    out: &Path,
+) -> Result<(), Error> {
+    let span = Span::current();
+    let manifest_path = if let Some(manifest_path) = manifest_path {
+        manifest_path.clone()
+    } else {
+        ProjectManifest::discover(&current_dir()?)?
+    };
+    span.record(
+        "manifest_path",
+        tracing::field::display(manifest_path.display()),
+    );
+
+    let state = State::load(&ctx.config).await?;
+    let maybe_client = if !offline {
+        Some(DownloadServerClient::new(&ctx.config, &state))
+    } else {
+        None
+    };
+    let cache = DownloadServerCache::new(&ctx.config.paths.cache_dir, &maybe_client).await?;
+    let keys = cache.keys().await?;
+
+    let project_manifest = ProjectManifest::load(&manifest_path)?;
+
+    tarball(cache, &keys, &project_manifest, out).await?;
+
+    Ok(())
+}
+
+
+#[tracing::instrument(level = "debug", skip_all, fields(product_path))]
+async fn tarball(
+    cache: DownloadServerCache<'_>,
+    keys: &Keychain,
+    project_manifest: &ProjectManifest,
+    output: &Path,
+) -> Result<(), Error> {
+
+    // Path to installables we will include in the tarball
+    // Note: Do not try to get clever and parallize the building of this, download
+    //       bandwidth is not generous for many people.
+    let mut installables = vec![];
+    
+    // Collect a list of installables
+    for product in project_manifest.products() {
+        let product_name = product.name();
+        let release = product.release();
+
+        for package in product.packages() {
+            let package_path = cache.package(product_name, release, package, DEFAULT_RELEASE_ARTIFACT_FORMAT).await?;
+            installables.push(package_path);
+        }
+    }
+
+    // Build a sysroot of the installables in a tempdir.
+    let working_dir = TempDir::new()?;
+    for installable in installables {
+        let working_path = working_dir.path().to_path_buf();
+        spawn_blocking(move || {
+            let file = std::fs::OpenOptions::new().read(true).open(installable)?;
+            let decoder = xz2::read::XzDecoder::new(file);
+            let mut archive = tar::Archive::new(decoder);
+            archive.set_preserve_permissions(true);
+            archive.set_preserve_mtime(true);
+            archive.set_unpack_xattrs(true);
+    
+            archive.unpack(working_path)
+        }).await??;
+    }
+
+    // Run the verifier over the tempdir.
+    tracing::info!("Verifying toolchain...");
+    let mut integrity_verifier = IntegrityVerifier::new(keys);
+    for entry in WalkDir::new(&working_dir) {
+        let entry = entry?;
+
+        if entry.file_type().is_file() {
+            tracing::trace!("Adding {}", tracing::field::display(entry.path().display()));
+
+            #[cfg(not(windows))]
+            let mode = entry.metadata()?.mode();
+            // Windows does not have the same concept of permissions, we just no-op mode.
+            #[cfg(windows)]
+            let mode = 0;
+
+            integrity_verifier.add(entry.path(), mode, &tokio::fs::read(&entry.path()).await?);
+        }
+    }
+    integrity_verifier
+        .verify()
+        .map_err(Error::IntegrityErrorsWhileTarballing)?;
+    tracing::info!("Verified toolchain");
+
+    // Wrap it up.
+    tracing::info!(path = %output.display(), "Creating archive...");
+    let working_dir_owned = working_dir.path().to_path_buf();
+    let output_owned = output.to_path_buf();
+    spawn_blocking(move || {
+        // Tarballs kinda suck, we can't create them with absolute paths,
+        // so, we're forced to change directory.
+        let old_current_dir = std::env::current_dir()?;
+        let destination = old_current_dir.join(output_owned);
+        std::env::set_current_dir(working_dir_owned)?;
+        let out_file = OpenOptions::new().create_new(true).write(true).open(destination)?;
+        let mut archive = tar::Builder::new(&out_file);
+        archive.append_dir_all(".", ".")?;
+        archive.finish()?;
+        std::env::set_current_dir(old_current_dir)
+    }).await??;
+    tracing::info!(path = %output.display(), "Archive created successfully");
+
+    Ok(())
+}

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -53,11 +53,11 @@ pub(crate) enum Error {
         .0.iter().map(|err| { err.to_string() }).collect::<Vec<_>>().join("\n")
     )]
     IntegrityErrorsWhileVerifying(Vec<IntegrityError>),
-    #[error("Some files did not pass the integrity checks during tarballing.\n \
+    #[error("Some files did not pass the integrity checks during archiving.\n \
         The following errors were found:\n\n{}",
         .0.iter().map(|err| { err.to_string() }).collect::<Vec<_>>().join("\n")
     )]
-    IntegrityErrorsWhileTarballing(Vec<IntegrityError>),
+    IntegrityErrorsWhileArchiving(Vec<IntegrityError>),
 
     #[error(transparent)]
     MissingRevocationInfo(#[from] IntegrityError),

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -5,7 +5,6 @@ use criticaltrust::integrity::IntegrityError;
 pub(crate) use criticaltrust::Error as TrustError;
 pub(crate) use criticalup_core::errors::BinaryProxyUpdateError;
 pub(crate) use criticalup_core::errors::Error as LibError;
-use tokio::task::JoinError;
 use std::path::PathBuf;
 use std::string::FromUtf8Error as Utf8Error;
 use tokio::task::JoinError;

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -5,6 +5,7 @@ use criticaltrust::integrity::IntegrityError;
 pub(crate) use criticaltrust::Error as TrustError;
 pub(crate) use criticalup_core::errors::BinaryProxyUpdateError;
 pub(crate) use criticalup_core::errors::Error as LibError;
+use tokio::task::JoinError;
 use std::path::PathBuf;
 use std::string::FromUtf8Error as Utf8Error;
 use tokio::task::JoinError;
@@ -53,6 +54,11 @@ pub(crate) enum Error {
         .0.iter().map(|err| { err.to_string() }).collect::<Vec<_>>().join("\n")
     )]
     IntegrityErrorsWhileVerifying(Vec<IntegrityError>),
+    #[error("Some files did not pass the integrity checks during tarballing.\n \
+        The following errors were found:\n\n{}",
+        .0.iter().map(|err| { err.to_string() }).collect::<Vec<_>>().join("\n")
+    )]
+    IntegrityErrorsWhileTarballing(Vec<IntegrityError>),
 
     #[error(transparent)]
     MissingRevocationInfo(#[from] IntegrityError),

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -203,7 +203,7 @@ enum Commands {
         /// Path to output the tarball to (else use stdout)
         #[arg()]
         out: Option<PathBuf>,
-    }
+    },
 }
 
 #[derive(Debug, Subcommand, Clone)]

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -200,7 +200,7 @@ enum Commands {
         /// Don't download from the server, only use previously cached artifacts
         #[arg(long)]
         offline: bool,
-        /// Path to output the tarball to (else use stdout)
+        /// Path to output the archive to (else use stdout)
         #[arg()]
         out: Option<PathBuf>,
     },

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -200,9 +200,9 @@ enum Commands {
         /// Don't download from the server, only use previously cached artifacts
         #[arg(long)]
         offline: bool,
-        /// Path to output the tarball to
+        /// Path to output the tarball to (else use stdout)
         #[arg()]
-        out: PathBuf,
+        out: Option<PathBuf>,
     }
 }
 

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -70,11 +70,11 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
             binary: tool,
             project,
         } => commands::which::run(&ctx, tool, project).await?,
-        Commands::Tarball {
+        Commands::Archive {
             offline,
             project,
             out,
-        } => commands::tarball::run(&ctx, project.as_ref(), offline, out.as_ref()).await?,
+        } => commands::archive::run(&ctx, project.as_ref(), offline, out.as_ref()).await?,
     }
 
     Ok(())
@@ -192,8 +192,8 @@ enum Commands {
         project: Option<PathBuf>,
     },
 
-    /// Create a tarball of the toolchain based on the manifest `criticalup.toml`
-    Tarball {
+    /// Create a tar archive of the toolchain based on the manifest `criticalup.toml`
+    Archive {
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -70,6 +70,11 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
             binary: tool,
             project,
         } => commands::which::run(&ctx, tool, project).await?,
+        Commands::Tarball {
+            offline,
+            project,
+            out,
+        } => commands::tarball::run(&ctx, project.as_ref(), offline, out.as_ref()).await?,
     }
 
     Ok(())
@@ -186,6 +191,19 @@ enum Commands {
         #[arg(long)]
         project: Option<PathBuf>,
     },
+
+    /// Create a tarball of the toolchain based on the manifest `criticalup.toml`
+    Tarball {
+        /// Path to the manifest `criticalup.toml`
+        #[arg(long)]
+        project: Option<PathBuf>,
+        /// Don't download from the server, only use previously cached artifacts
+        #[arg(long)]
+        offline: bool,
+        /// Path to output the tarball to
+        #[arg()]
+        out: PathBuf,
+    }
 }
 
 #[derive(Debug, Subcommand, Clone)]

--- a/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
@@ -21,7 +21,7 @@ Commands:
   remove   Delete all the products specified in the manifest `criticalup.toml`
   verify   Verify a given toolchain
   which    Display which binary will be run for a given command
-  tarball  Create a tarball of the toolchain based on the manifest `criticalup.toml`
+  archive  Create a tar archive of the toolchain based on the manifest `criticalup.toml`
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace

--- a/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
@@ -21,6 +21,7 @@ Commands:
   remove   Delete all the products specified in the manifest `criticalup.toml`
   verify   Verify a given toolchain
   which    Display which binary will be run for a given command
+  tarball  Create a tarball of the toolchain based on the manifest `criticalup.toml`
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace

--- a/crates/criticalup-core/Cargo.toml
+++ b/crates/criticalup-core/Cargo.toml
@@ -25,4 +25,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 mock-download-server = { path = "../mock-download-server" }
-tempfile = "3.10.1"
+tempfile.workspace = true

--- a/crates/criticalup-core/src/download_server_cache.rs
+++ b/crates/criticalup-core/src/download_server_cache.rs
@@ -54,6 +54,8 @@ impl<'a> DownloadServerCache<'a> {
         self.root.join("keys.json")
     }
 
+    /// Return the path to a package which either already existed in the cache, or is freshly
+    /// downloaded.
     #[tracing::instrument(level = "debug", skip_all, fields(
         %product,
         %release,

--- a/docs/src/using-criticalup/toolchain-management.rst
+++ b/docs/src/using-criticalup/toolchain-management.rst
@@ -83,8 +83,8 @@ Then run the install command again:
 
    criticalup install
 
-When an internet connection is not available, a previously installed package
-can be reinstalled without using the network by passing the ``--offline`` flag.
+When an internet connection is not available, a previously fetched package
+can be installed without using the network by passing the ``--offline`` flag.
 
 Removing Toolchains
 ^^^^^^^^^^^^^^^^^^^
@@ -94,7 +94,6 @@ from the directory containing the ``criticalup.toml``:
 
 .. code-block::
 
-   cd project
    criticalup remove
 
 Cleaning Unused Toolchains
@@ -120,3 +119,19 @@ From the direcory containing the relevant ``criticalup.toml``:
 .. code-block::
 
    criticalup verify
+
+Creating Archives of Toolchains
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+CriticalUp can produce uncompressed tarballs of toolchains which can then be
+placed in backups.
+
+.. code-block::
+
+   criticalup tarball out.tar
+
+If an output path is omitted, ``criticalup tarball`` emits the archive to
+stdout.
+
+When an internet connection is not available, a previously fetched package
+can be tarballed without using the network by passing the ``--offline`` flag.

--- a/docs/src/using-criticalup/toolchain-management.rst
+++ b/docs/src/using-criticalup/toolchain-management.rst
@@ -128,9 +128,9 @@ placed in backups.
 
 .. code-block::
 
-   criticalup tarball out.tar
+   criticalup archive out.tar
 
-If an output path is omitted, ``criticalup tarball`` emits the archive to
+If an output path is omitted, ``criticalup archive`` emits the archive to
 stdout.
 
 When an internet connection is not available, a previously fetched package


### PR DESCRIPTION
Sketch out a `criticalup archive` command.

To test:

* chdir to a criticalup project
* run `cargo run -- archive > floop.tar` to test stdout support
* Run `criticalup archive bloop.tar` to test outputting to a file

To test `--offline`:

* chdir to a criticalup project
* run `cargo run -- clean`
* run `cargo run -- archive --offline blerp.tar` -- This should fail.
* run `cargo run -- archive swerp.tar` -- This should have output that it is downloading.
* run `cargo run -- archive --offline fwop.tar` -- This should work.

Also try testing the optional `--project` flag which does not require a chdir.