### PR TITLE
Wait for localstack health in kms tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "once_cell",
  "p256",
  "rand_core",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-members = ["crates/criticalup"]
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "process"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots"] }
 reqwest-middleware = "0.3"
 reqwest-retry = "0.6"
 tracing = "0.1"

--- a/crates/criticaltrust/Cargo.toml
+++ b/crates/criticaltrust/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1.19.0"
 [dev-dependencies]
 itertools = "0.13.0"
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread", "macros"] }
+reqwest.workspace = true
 
 [features]
 aws-kms = ["aws-sdk-kms", "aws-config", "aws-smithy-runtime-api", "tokio"]

--- a/crates/criticalup-core/Cargo.toml
+++ b/crates/criticalup-core/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 [dependencies]
 criticaltrust = { path = "../criticaltrust" }
 log = "0.4.21"
-reqwest = { version = "0.12.4", default-features = false, features = ["blocking", "json", "rustls-tls", "rustls-tls-native-roots"] }
+reqwest.workspace = true
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
 thiserror = "1.0.61"


### PR DESCRIPTION
Now when we start localstack we wait for it to come alive before going farther.