### PR TITLE
Do not check for expiration date on revocation info when installing in `--offline` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this project will be documented in this file.
   is not corrupted or tampered with.
 - Added `criticalup archive` which creates an archive of the toolchain for cold storage or backup.
 
+## Fixed
+
+- Bug when using `--offline` mode to install with expired revocation info ends in installation failure. To
+  support proper `--offline` mode, the expiration date on revocation info hash must be ignored.
+
 ## [1.1.0] - 2024-08-28
 
 ## Added


### PR DESCRIPTION
## Summary

This is a bugfix for when installing a product in `--offline` mode still checks the expiration date of the revocation info hash. Which means that if the date is expired the installation fails. This is counter to the logic of `--offline` mode where we are unable to check for the latest updates on hashes and expiration dates.

## Testing

Perhaps use the dev environment to test this by pushing an expired hash. However, two unit tests have been added.

### Commands

First install a fresh product

```sh
cargo run clean

cargo run install --project /path/to/criticalup.toml
```

Then run with `--offline` mode

```sh
cargo run install  --project /path/to/criticalup.toml --offline --reinstall

```
