### PR TITLE
Redirects API - Client support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Added
+
+- Client-side handling of release redirects in `criticalup.toml` where users can specify release as
+  `@nightly/latest` to get the latest release from the `nightly` channel.
+
 ### Changed
 
 - Standardized error messages as close to English rules as possible.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
 name = "criticalup-core"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "criticaltrust",
  "dirs",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,9 +1451,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libredox"
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.5"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -1790,7 +1790,6 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.11",
- "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -1798,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.8"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
 dependencies = [
  "bytes",
  "rand",
@@ -1815,15 +1814,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.5"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
 dependencies = [
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2082,9 +2081,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -3126,15 +3125,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/criticaltrust/src/manifests.rs
+++ b/crates/criticaltrust/src/manifests.rs
@@ -68,14 +68,14 @@ impl Signable for Redirect {
 
 // Releases
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReleaseManifest {
     pub version: ManifestVersion<1>,
     #[serde(flatten)]
     pub signed: SignedPayload<Release>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Release {
     pub product: String,
     pub release: String,
@@ -87,14 +87,14 @@ impl Signable for Release {
     const SIGNED_BY_ROLE: KeyRole = KeyRole::Releases;
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ReleasePackage {
     pub package: String,
     pub artifacts: Vec<ReleaseArtifact>,
     pub dependencies: Vec<String>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ReleaseArtifact {
     pub format: ReleaseArtifactFormat,
     pub size: usize,
@@ -102,7 +102,7 @@ pub struct ReleaseArtifact {
     pub sha256: Vec<u8>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Copy)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Copy, Eq)]
 pub enum ReleaseArtifactFormat {
     #[serde(rename = "tar.zst")]
     TarZst,

--- a/crates/criticaltrust/src/signatures/payload.rs
+++ b/crates/criticaltrust/src/signatures/payload.rs
@@ -11,7 +11,7 @@ use std::cell::{Ref, RefCell};
 ///
 /// To prevent misuses, there is no way to access the data inside the payload unless signatures are
 /// verified. The signed payload can be freely serialized and deserialized.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(bound = "T: Signable")]
 pub struct SignedPayload<T: Signable> {
     signatures: Vec<Signature>,
@@ -125,7 +125,7 @@ fn verify_signature<T: Signable>(
     Err(Error::VerificationFailed)
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 struct Signature {
     key_sha256: KeyId,
     #[serde(with = "crate::serde_base64")]

--- a/crates/criticalup-cli/tests/cli/utils.rs
+++ b/crates/criticalup-cli/tests/cli/utils.rs
@@ -42,12 +42,12 @@ pub(crate) const MOCK_AUTH_TOKENS: &[(&str, AuthenticationToken)] = &[
 pub(crate) fn mock_release_manifests() -> Vec<(&'static str, &'static str, ReleaseManifest)> {
     vec![(
         "ferrocene",
-        "dev",
+        "stable-24.08",
         ReleaseManifest {
             version: criticaltrust::manifests::ManifestVersion,
             signed: SignedPayload::new(&Release {
                 product: "ferrocene".into(),
-                release: "dev".into(),
+                release: "stable-24.08".into(),
                 commit: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".into(),
                 packages: vec![],
             })

--- a/crates/criticalup-core/Cargo.toml
+++ b/crates/criticalup-core/Cargo.toml
@@ -26,3 +26,4 @@ tracing.workspace = true
 [dev-dependencies]
 mock-download-server = { path = "../mock-download-server" }
 tempfile.workspace = true
+anyhow = "1.0"

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -72,8 +72,6 @@ impl DownloadServerClient {
         product: &str,
         release: &str,
     ) -> Result<ReleaseManifest, Error> {
-        // TODO: tests
-
         let mut url = format!("/v1/releases/{product}/{release}");
 
         if let Some(stripped) = release.strip_prefix('@') {

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -220,8 +220,8 @@ mod tests {
     use super::*;
     use crate::state::AuthenticationToken;
     use crate::test_utils::{
-        TestEnvironment, SAMPLE_AUTH_TOKEN_CUSTOMER, SAMPLE_AUTH_TOKEN_EXPIRY,
-        SAMPLE_AUTH_TOKEN_NAME,
+        sample_release_manifest, TestEnvironment, SAMPLE_AUTH_TOKEN_CUSTOMER,
+        SAMPLE_AUTH_TOKEN_EXPIRY, SAMPLE_AUTH_TOKEN_NAME,
     };
     use criticaltrust::keys::KeyPair;
     use criticaltrust::signatures::PublicKeysRepository;
@@ -313,6 +313,26 @@ mod tests {
                 .get(&expected_missing.public().calculate_id())
                 .is_none());
         }
+    }
+
+    /// Get the release via the redirects API endpoint.
+    ///
+    /// The following TODOs are to be done post-merge of test utils which are currently spread
+    /// out into multiple crates.
+    /// TODO: Add tests for actual release endpoint.
+    /// TODO: Add multiple releases to be able to return the latest.
+    #[tokio::test]
+    async fn test_get_release_redirect() -> anyhow::Result<()> {
+        let test_env = TestEnvironment::with().download_server().prepare().await;
+        let actual_manifest = test_env
+            .download_server()
+            .get_product_release_manifest("ferrocene", "@stable-24.08/latest")
+            .await?;
+        let expected_manifest = sample_release_manifest();
+
+        assert_eq!(actual_manifest, expected_manifest);
+
+        Ok(())
     }
 
     async fn assert_auth_failed(test_env: &TestEnvironment) {

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -97,10 +97,10 @@ pub enum Error {
     KeychainLoadingFailed(#[source] criticaltrust::Error),
 
     #[error(
-        "The `release` in your project manifest does not seem to be correct.\n  \
-    If you want to specify latest release from a channel, please use '@' symbol as the first \
-    character, then the channel name, then the symbol '/', and then the word 'latest'.\n  \
-    Your `release`: .release"
+        "The 'release' in your project manifest does not seem to be correct.\n  \
+    If you want to specify latest release from a channel, please use the pattern \
+    '@channel/latest'.\n  \
+    Your 'release': '{release}'"
     )]
     MalformedReleaseNameRedirect { release: String },
 }

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -95,6 +95,14 @@ pub enum Error {
 
     #[error("Failed to load keys into keychain.")]
     KeychainLoadingFailed(#[source] criticaltrust::Error),
+
+    #[error(
+        "The `release` in your project manifest does not seem to be correct.\n  \
+    If you want to specify latest release from a channel, please use '@' symbol as the first \
+    character, then the channel name, then the symbol '/', and then the word 'latest'.\n  \
+    Your `release`: .release"
+    )]
+    MalformedReleaseNameRedirect { release: String },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/criticalup-core/src/test_utils.rs
+++ b/crates/criticalup-core/src/test_utils.rs
@@ -5,6 +5,7 @@ use crate::config::Config;
 use crate::download_server_client::DownloadServerClient;
 use crate::state::{AuthenticationToken, State};
 use criticaltrust::keys::{EphemeralKeyPair, KeyAlgorithm, KeyPair, KeyRole, PublicKey};
+use criticaltrust::manifests::{ManifestVersion, Release, ReleaseManifest};
 use criticaltrust::signatures::SignedPayload;
 use mock_download_server::MockServer;
 use std::path::Path;
@@ -248,5 +249,22 @@ async fn start_mock_server(
 
     builder = builder.add_revocation_info(revocation_key).await;
 
+    // Add a sample release manifest.
+    let rm = sample_release_manifest();
+    builder = builder.add_release_manifest("ferrocene".to_string(), "stable-24.08".to_string(), rm);
+
     builder.start()
+}
+
+pub(crate) fn sample_release_manifest() -> ReleaseManifest {
+    ReleaseManifest {
+        version: ManifestVersion,
+        signed: SignedPayload::new(&Release {
+            product: "ferrocene".into(),
+            release: "stable-24.08".into(),
+            commit: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".into(),
+            packages: vec![],
+        })
+        .unwrap(),
+    }
 }

--- a/crates/mock-download-server/src/handlers.rs
+++ b/crates/mock-download-server/src/handlers.rs
@@ -19,6 +19,9 @@ pub(crate) fn handle_request(data: &Data, req: &Request) -> ResponseBox {
         (Method::Get, ["v1", "releases", product, release]) => {
             handle_v1_release(data, product, release)
         }
+        (Method::Get, ["v1", "redirects", product, release, "latest"]) => {
+            handle_v1_redirects(data, product, release)
+        }
         _ => handle_404(),
     };
 
@@ -44,6 +47,14 @@ fn handle_v1_keys(data: &Data) -> Result<Resp, Resp> {
 }
 
 fn handle_v1_release(data: &Data, product: &str, release: &str) -> Result<Resp, Resp> {
+    let rm = data
+        .release_manifests
+        .get(&(product.to_string(), release.to_string()));
+    let resp = Resp::json(rm.expect("Did not get a release manifest"));
+    Ok(resp)
+}
+
+fn handle_v1_redirects(data: &Data, product: &str, release: &str) -> Result<Resp, Resp> {
     let rm = data
         .release_manifests
         .get(&(product.to_string(), release.to_string()));

--- a/crates/mock-download-server/src/lib.rs
+++ b/crates/mock-download-server/src/lib.rs
@@ -17,7 +17,7 @@ use time::{Duration, OffsetDateTime};
 // Make sure there is enough number of days for expiration so tests don't need constant updates.
 const EXPIRATION_EXTENSION_IN_DAYS: Duration = Duration::days(180);
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct AuthenticationToken {
     pub name: Cow<'static, str>,
@@ -25,6 +25,7 @@ pub struct AuthenticationToken {
     pub expires_at: Option<Cow<'static, str>>,
 }
 
+#[derive(Debug)]
 pub struct Data {
     pub tokens: HashMap<String, AuthenticationToken>,
     pub keys: Vec<SignedPayload<PublicKey>>,

--- a/docs/src/criticalup_toml.rst
+++ b/docs/src/criticalup_toml.rst
@@ -87,11 +87,8 @@ channels page <https://releases.ferrocene.dev/ferrocene/index.html>`_.
     release = "stable-24.05.0"
     # ...
 
-**Getting the latest release in a channel**
-
-Sometimes you may want the latest release for a given channel. You can use
-the following pattern to achieve that. In the following example, you will
-get latest release in the stable-24.05 channel.
+The latest release in a given channel can be installed using ``@channel/latest``. The
+following example will install the latest release in ``stable-24.05`` channel.
 
 .. code-block::
 

--- a/docs/src/criticalup_toml.rst
+++ b/docs/src/criticalup_toml.rst
@@ -90,13 +90,13 @@ channels page <https://releases.ferrocene.dev/ferrocene/index.html>`_.
 **Getting the latest release in a channel**
 
 Sometimes you may want the latest release for a given channel. You can use
-the following pattern to achieve that. Here you will get latest release in
-the nightly channel.
+the following pattern to achieve that. In the following example, you will
+get latest release in the stable-24.05 channel.
 
 .. code-block::
 
     [products.ferrocene]
-    release = "@nightly/latest"
+    release = "@stable-24.05/latest"
     # ...
 
 ``packages``

--- a/docs/src/criticalup_toml.rst
+++ b/docs/src/criticalup_toml.rst
@@ -87,11 +87,14 @@ channels page <https://releases.ferrocene.dev/ferrocene/index.html>`_.
     release = "stable-24.05.0"
     # ...
 
+**Getting the latest release in a channel**
+
 Sometimes you may want the latest release for a given channel. You can use
 the following pattern to achieve that. Here you will get latest release in
 the nightly channel.
 
 .. code-block::
+
     [products.ferrocene]
     release = "@nightly/latest"
     # ...

--- a/docs/src/criticalup_toml.rst
+++ b/docs/src/criticalup_toml.rst
@@ -87,6 +87,15 @@ channels page <https://releases.ferrocene.dev/ferrocene/index.html>`_.
     release = "stable-24.05.0"
     # ...
 
+Sometimes you may want the latest release for a given channel. You can use
+the following pattern to achieve that. Here you will get latest release in
+the nightly channel.
+
+.. code-block::
+    [products.ferrocene]
+    release = "@nightly/latest"
+    # ...
+
 ``packages``
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
Note: This will only work with the dev server right now. That is primarily the reason this is a draft PR.

# Testing instructions

## Project manifest

Create a project manifest with content:

```toml
manifest-version = 1

[products.ferrocene]
release = "@stable-24.05/latest"
packages = [
    "rustc-x86_64-unknown-linux-gnu"
]
```

Note the `release = "@stable-24.05/latest"` line that tells the client to ask the server for the latest release in the stable-24.05 channel.

Save this file. We will call this file `criticalup.toml`.

## Run `install` command

```sh
cargo run -q --package criticalup-dev install --project criticalup.toml
```

The part `--package criticalup-dev` tells cargo to use `criticalup-dev` binary instead of default because we can only test this with dev server as of right now.

## Output

You should see a successful output of 

```sh
 INFO Installing product 'ferrocene' (@stable-24.05/latest)
 INFO Resolved '@stable-24.05/latest' to release 'stable-24.05.0'
 INFO Downloading component 'rustc-x86_64-unknown-linux-gnu' for 'ferrocene' (stable-24.05.0)
 INFO Installing component 'rustc-x86_64-unknown-linux-gnu' for 'ferrocene' (stable-24.05.0)
```

The `@stable-24.05/latest` was resolved to `stable-24.05.0`.

To further check if it is indeed the latest one, you can run 

```sh
cargo run -q --package criticalup-dev run --project criticalup.toml rustc --version
```

This should print

```sh
rustc 1.76.0 (5f6ca3d45 2024-05-22) (Ferrocene by Ferrous Systems)
```