### PR TITLE
Add Changelog to CriticalUp documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@ All notable changes to this project will be documented in this file.
   is not corrupted or tampered with.
 - Added `criticalup archive` which creates an archive of the toolchain for cold storage or backup.
 
-## Fixed
+### Fixed
 
 - Bug when using `--offline` mode to install with expired revocation info ends in installation failure. To
   support proper `--offline` mode, the expiration date on revocation info hash must be ignored.
 
 ## [1.1.0] - 2024-08-28
 
-## Added
+### Added
 
 - Support for package revocation added, `criticalup install` will verify packages have not been
   revoked (due to, for example, a security event) before installation.

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -1,0 +1,7 @@
+.. SPDX-FileCopyrightText: The Ferrocene Developers
+.. SPDX-License-Identifier: MIT OR Apache-2.0
+
+.. _changelog:
+
+.. include:: ../../CHANGELOG.md
+    :parser: myst_parser.sphinx_

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "ferrocene_intersphinx_support",
     "ferrocene_qualification",
     "ferrocene_domain_cli",
+    "myst_parser",
 ]
 
 # autosectionlabel unique names settings

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -35,6 +35,7 @@ CriticalUp User Documentation
    :caption: Reference:
 
    criticalup_toml
+   changelog
 
 Indices and tables
 ------------------


### PR DESCRIPTION
The Changelog will show in https://criticalup.ferrocene.dev/ under References section.