### PR TITLE
Release/v.1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.2.0] - 2024-11-25
 
 ### Changed
 
@@ -66,7 +66,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/ferrocene/criticalup/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/ferrocene/criticalup/compare/v1.1.0...v1.0.2
 [1.0.2]: https://github.com/ferrocene/criticalup/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ferrocene/criticalup/compare/v1.0.0...v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-cli"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "clap",
  "criticaltrust",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-dev"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-cli"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 repository = "https://github.com/ferrocene/criticalup"
 homepage = "https://github.com/ferrocene/criticalup"

--- a/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
@@ -8,5 +8,5 @@ empty stdout
 
 stderr
 ------
-criticalup-test 1.1.0
+criticalup-test 1.2.0
 ------

--- a/crates/criticalup-dev/Cargo.toml
+++ b/crates/criticalup-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-dev"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 publish = false
 

--- a/crates/criticalup/Cargo.toml
+++ b/crates/criticalup/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 authors = ["The CriticalUp Developers"]
 description = "Ferrocene toolchain manager"


### PR DESCRIPTION
Release 1.2.0 (we attempted this in #65 however the release job failed -- no artifacts were published -- so we reverted and deleted the tag. This is a re-attempt of that.)