### PR TITLE
criticalup run without proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- `criticalup run` now behaves more similar to `rustup run` and `uv run`, allowing you to run
+  `criticalup run $WHATEVER` and have the respective tool see the appropriate CriticalUp-managed tools
+  within the `$PATH` (or equivalent).
+
 ### Added
 
 - Release instructions to README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 
 - `criticalup run` now behaves more similar to `rustup run` and `uv run`, allowing you to run
   `criticalup run $WHATEVER` and have the respective tool see the appropriate CriticalUp-managed tools
-  within the `$PATH` (or equivalent).
+  within the `$PATH` (or equivalent). A `--strict` flag was added to make it possible to ensure only
+  tools within the installation are run.
 
 ### Added
 

--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -143,7 +143,7 @@ pub(crate) fn arg0(whitelabel: &WhitelabelConfig) -> Result<String, Error> {
         .map(|s| s.to_string())
 }
 
-fn prepend_path_to_var_for_command(
+pub(crate) fn prepend_path_to_var_for_command(
     command: &mut Command,
     env_var: &str,
     new: Vec<PathBuf>,

--- a/crates/criticalup-cli/src/commands/run.rs
+++ b/crates/criticalup-cli/src/commands/run.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::commands::which::locate_binary;
+use criticalup_core::project_manifest::ProjectManifest;
+
+use crate::binary_proxies::prepend_path_to_var_for_command;
 use crate::errors::Error;
 use crate::spawn::spawn_command;
 use crate::Context;
@@ -11,24 +13,69 @@ use std::process::{Command, Stdio};
 
 pub(crate) async fn run(
     ctx: &Context,
-    command: Vec<String>,
+    user_command: Vec<String>,
     project: Option<PathBuf>,
 ) -> Result<(), Error> {
-    let binary = if let Some(binary) = command.first() {
-        binary.clone()
-    } else {
-        return Err(Error::BinaryNotInstalled(String::new()));
-    };
-    let found_binary = locate_binary(ctx, binary, project).await?;
+    let installations = locate_installations(ctx, project).await?;
+    let mut bin_paths = vec![];
+    let mut lib_paths = vec![];
+    for installation in installations {
+        let bin_dir = installation.join("bin");
+        if bin_dir.exists() {
+            bin_paths.push(bin_dir);
+        }
+        let lib_dir = installation.join("lib");
+        if lib_dir.exists() {
+            lib_paths.push(lib_dir)
+        }
+    }
 
-    let args = command.get(1..).unwrap_or(&[]);
-    let mut cmd = Command::new(found_binary);
-    cmd.args(args)
+    let binary = user_command
+        .first()
+        .ok_or(Error::BinaryNotInstalled(String::new()))?;
+    let args = user_command.get(1..).unwrap_or(&[]);
+    let mut command = Command::new(binary);
+
+    command
+        .args(args)
         .stdout(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());
 
-    spawn_command(cmd)?;
+    // For some particularly niche use cases, users may find themselves wanting
+    // to override the `rustc` called, and they may want to do that by setting
+    // `PATH` themselves, but they:
+    // 1) Shouldn't do that, and
+    // 2) Can set `RUSTC` which `cargo` already supports.
+
+    #[cfg(target_os = "macos")]
+    prepend_path_to_var_for_command(&mut command, "DYLD_FALLBACK_LIBRARY_PATH", lib_paths)?;
+    #[cfg(target_os = "linux")]
+    prepend_path_to_var_for_command(&mut command, "LD_LIBRARY_PATH", lib_paths)?;
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    prepend_path_to_var_for_command(&mut command, "PATH", bin_paths)?;
+    #[cfg(target_os = "windows")]
+    prepend_path_to_var_for_command(&mut command, "PATH", [lib_paths, bin_paths].concat())?;
+
+    spawn_command(command)?;
 
     Ok(())
+}
+
+#[tracing::instrument(level = "debug", skip_all, fields(binary, project))]
+pub(crate) async fn locate_installations(
+    ctx: &Context,
+    project: Option<PathBuf>,
+) -> Result<Vec<PathBuf>, Error> {
+    let manifest = ProjectManifest::get(project).await?;
+
+    let installation_dir = &ctx.config.paths.installation_dir;
+
+    let mut found_installation_dirs = vec![];
+    for product in manifest.products() {
+        let abs_installation_dir_path = installation_dir.join(product.installation_id());
+        found_installation_dirs.push(abs_installation_dir_path);
+    }
+
+    Ok(found_installation_dirs)
 }

--- a/crates/criticalup-cli/src/commands/run.rs
+++ b/crates/criticalup-cli/src/commands/run.rs
@@ -48,7 +48,7 @@ pub(crate) async fn run(
             // This should never happen, the user somehow passed an empty string which clap somehow did not detect.
             panic!("Unexpected error: In strict mode an empty string was found as a binary name, this code should have never been reached. Please report this.");
         }; // `Components` has no `len`
-        if components.next() != None {
+        if components.next().is_none() {
             // In strict mode, the specified binary cannot be anything other than a single path component,
             // since it must be present in one of the bin dirs of the installations.
             return Err(Error::StrictModeDoesNotAcceptPaths);

--- a/crates/criticalup-cli/src/commands/run.rs
+++ b/crates/criticalup-cli/src/commands/run.rs
@@ -47,8 +47,8 @@ pub(crate) async fn run(
         let Some(binary_name) = components.next() else {
             // This should never happen, the user somehow passed an empty string which clap somehow did not detect.
             panic!("Unexpected error: In strict mode an empty string was found as a binary name, this code should have never been reached. Please report this.");
-        }; // `Components` has no `len`
-        if components.next().is_none() {
+        };
+        if components.next().is_some() {
             // In strict mode, the specified binary cannot be anything other than a single path component,
             // since it must be present in one of the bin dirs of the installations.
             return Err(Error::StrictModeDoesNotAcceptPaths);

--- a/crates/criticalup-cli/src/commands/run.rs
+++ b/crates/criticalup-cli/src/commands/run.rs
@@ -1,11 +1,10 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::commands::which::locate_binary;
 use crate::errors::Error;
-use crate::errors::Error::BinaryNotInstalled;
 use crate::spawn::spawn_command;
 use crate::Context;
-use criticalup_core::project_manifest::ProjectManifest;
 use std::path::PathBuf;
 // We *deliberately* use a sync Command here, since we are spawning a process to replace the current one.
 use std::process::{Command, Stdio};
@@ -15,48 +14,21 @@ pub(crate) async fn run(
     command: Vec<String>,
     project: Option<PathBuf>,
 ) -> Result<(), Error> {
-    // We try to fetch the manifest early on because it makes failing fast easy. Given that we need
-    // this variable to set the env var later for child process, it is important to try to get the
-    // canonical path first.
-    let manifest_path = ProjectManifest::discover_canonical_path(project.as_deref()).await?;
+    let binary = if let Some(binary) = command.first() {
+        binary.clone()
+    } else {
+        return Err(Error::BinaryNotInstalled(String::new()));
+    };
+    let found_binary = locate_binary(ctx, binary, project).await?;
 
-    // This dir has all the binaries that are proxied.
-    let proxies_dir = &ctx.config.paths.proxies_dir;
+    let args = command.get(1..).unwrap_or(&[]);
+    let mut cmd = Command::new(found_binary);
+    cmd.args(args)
+        .stdout(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
 
-    if let Some(binary_command) = command.first() {
-        let mut binary_executable = PathBuf::new();
-        binary_executable.set_file_name(binary_command);
-        // On Windows, the user can pass (for example) `cargo` or `cargo.exe`
-        #[cfg(windows)]
-        binary_executable.set_extension("exe");
-
-        let binary_path = proxies_dir.join(binary_executable);
-
-        if binary_path.exists() {
-            let args = command.get(1..).unwrap_or(&[]);
-            let mut cmd = Command::new(binary_path);
-            cmd.args(args)
-                .stdout(Stdio::inherit())
-                .stdout(Stdio::inherit())
-                .stderr(Stdio::inherit());
-
-            // Set the manifest path env CRITICALUP_CURRENT_PROJ_MANIFEST_CANONICAL_PATH var which is used
-            // by the function `crates::criticalup-cli::binary_proxies::proxy` to find the correct project
-            // manifest.
-            //
-            // Important: This env var is strictly for internal use!
-            if manifest_path.exists() {
-                cmd.env(
-                    "CRITICALUP_CURRENT_PROJ_MANIFEST_CANONICAL_PATH",
-                    manifest_path.as_os_str(),
-                );
-            }
-
-            spawn_command(cmd)?;
-        } else {
-            return Err(BinaryNotInstalled(binary_command.into()));
-        }
-    }
+    spawn_command(cmd)?;
 
     Ok(())
 }

--- a/crates/criticalup-cli/src/commands/run.rs
+++ b/crates/criticalup-cli/src/commands/run.rs
@@ -31,9 +31,11 @@ pub(crate) async fn run(
         }
     }
 
-    let mut binary = PathBuf::from(user_command
-        .first()
-        .ok_or(Error::BinaryNotInstalled(String::new()))?);
+    let mut binary = PathBuf::from(
+        user_command
+            .first()
+            .ok_or(Error::BinaryNotInstalled(String::new()))?,
+    );
     let args = user_command.get(1..).unwrap_or(&[]);
 
     // If `strict` is passed, the user wants to be absolutely sure they only run a binary from
@@ -43,13 +45,13 @@ pub(crate) async fn run(
     if strict {
         let mut components = binary.components();
         let Some(binary_name) = components.next() else {
-            // This should never happen, the user somehow passed an empty string which clap somehow did not detect. 
+            // This should never happen, the user somehow passed an empty string which clap somehow did not detect.
             panic!("Unexpected error: In strict mode an empty string was found as a binary name, this code should have never been reached. Please report this.");
         }; // `Components` has no `len`
         if components.next() != None {
             // In strict mode, the specified binary cannot be anything other than a single path component,
             // since it must be present in one of the bin dirs of the installations.
-            return Err(Error::StrictModeDoesNotAcceptPaths)
+            return Err(Error::StrictModeDoesNotAcceptPaths);
         }
         let mut found_binary = None;
         // In strict mode, the binary must exist on one of the bin paths
@@ -61,7 +63,7 @@ pub(crate) async fn run(
                     // that are ambiguous (we do not distribute such things).
                     // Invite them to specify which one using an absolute path.
                     let candidates = vec![duplicated_binary, candidate_binary];
-                    return Err(Error::BinaryAmbiguous(candidates))
+                    return Err(Error::BinaryAmbiguous(candidates));
                 } else {
                     found_binary = Some(candidate_binary)
                 }
@@ -71,7 +73,9 @@ pub(crate) async fn run(
             binary = found_binary;
         } else {
             // Did not find a binary to strictly run
-            return Err(Error::BinaryNotInstalled(binary.to_string_lossy().to_string()))
+            return Err(Error::BinaryNotInstalled(
+                binary.to_string_lossy().to_string(),
+            ));
         }
     }
 

--- a/crates/criticalup-cli/src/commands/run.rs
+++ b/crates/criticalup-cli/src/commands/run.rs
@@ -68,6 +68,8 @@ pub(crate) async fn run(
                     binary_name
                 }
             };
+            #[cfg(not(windows))]
+            let binary_name = binary_name.clone();
 
             let candidate_binary = bin_path.join(binary_name);
             if candidate_binary.exists() {

--- a/crates/criticalup-cli/src/commands/which.rs
+++ b/crates/criticalup-cli/src/commands/which.rs
@@ -9,38 +9,25 @@ use std::path::PathBuf;
 
 pub(crate) async fn run(
     ctx: &Context,
-    binary: String,
+    tool: String,
     project: Option<PathBuf>,
 ) -> Result<(), Error> {
-    let found_binary = locate_binary(ctx, binary, project).await?;
-    println!("{}\n", found_binary.display());
-
-    Ok(())
-}
-
-#[tracing::instrument(level = "debug", skip_all, fields(binary, project))]
-pub(crate) async fn locate_binary(
-    ctx: &Context,
-    binary: String,
-    project: Option<PathBuf>,
-) -> Result<PathBuf, Error> {
     let manifest = ProjectManifest::get(project).await?;
 
     let installation_dir = &ctx.config.paths.installation_dir;
 
-    let mut found_binary = None;
     for product in manifest.products() {
         let abs_installation_dir_path = installation_dir.join(product.installation_id());
 
         let bin_path = PathBuf::from("bin");
 
         let mut tool_executable = PathBuf::new();
-        tool_executable.set_file_name(&binary);
+        tool_executable.set_file_name(&tool);
 
         let tools_bin_path = abs_installation_dir_path.join(bin_path.join(&tool_executable));
 
         if tools_bin_path.exists() {
-            found_binary = Some(tools_bin_path);
+            println!("{}\n", tools_bin_path.display());
         } else {
             // On Windows, the user can pass (for example) `cargo` or `cargo.exe`
             #[cfg(windows)]
@@ -48,15 +35,15 @@ pub(crate) async fn locate_binary(
                 let mut tools_bin_path_with_exe = tools_bin_path.clone();
                 tools_bin_path_with_exe.set_extension("exe");
                 if tools_bin_path_with_exe.exists() {
-                    found_binary = Some(tools_bin_path_with_exe);
+                    println!("{}\n", tools_bin_path_with_exe.display());
+                } else {
+                    return Err(BinaryNotInstalled(tool));
                 }
             }
+            #[cfg(not(windows))]
+            return Err(BinaryNotInstalled(tool));
         }
     }
 
-    if let Some(found_binary) = found_binary {
-        Ok(found_binary)
-    } else {
-        Err(BinaryNotInstalled(binary))
-    }
+    Ok(())
 }

--- a/crates/criticalup-cli/src/commands/which.rs
+++ b/crates/criticalup-cli/src/commands/which.rs
@@ -9,25 +9,38 @@ use std::path::PathBuf;
 
 pub(crate) async fn run(
     ctx: &Context,
-    tool: String,
+    binary: String,
     project: Option<PathBuf>,
 ) -> Result<(), Error> {
+    let found_binary = locate_binary(ctx, binary, project).await?;
+    println!("{}\n", found_binary.display());
+
+    Ok(())
+}
+
+#[tracing::instrument(level = "debug", skip_all, fields(binary, project))]
+pub(crate) async fn locate_binary(
+    ctx: &Context,
+    binary: String,
+    project: Option<PathBuf>,
+) -> Result<PathBuf, Error> {
     let manifest = ProjectManifest::get(project).await?;
 
     let installation_dir = &ctx.config.paths.installation_dir;
 
+    let mut found_binary = None;
     for product in manifest.products() {
         let abs_installation_dir_path = installation_dir.join(product.installation_id());
 
         let bin_path = PathBuf::from("bin");
 
         let mut tool_executable = PathBuf::new();
-        tool_executable.set_file_name(&tool);
+        tool_executable.set_file_name(&binary);
 
         let tools_bin_path = abs_installation_dir_path.join(bin_path.join(&tool_executable));
 
         if tools_bin_path.exists() {
-            println!("{}\n", tools_bin_path.display());
+            found_binary = Some(tools_bin_path);
         } else {
             // On Windows, the user can pass (for example) `cargo` or `cargo.exe`
             #[cfg(windows)]
@@ -35,15 +48,15 @@ pub(crate) async fn run(
                 let mut tools_bin_path_with_exe = tools_bin_path.clone();
                 tools_bin_path_with_exe.set_extension("exe");
                 if tools_bin_path_with_exe.exists() {
-                    println!("{}\n", tools_bin_path_with_exe.display());
-                } else {
-                    return Err(BinaryNotInstalled(tool));
+                    found_binary = Some(tools_bin_path_with_exe);
                 }
             }
-            #[cfg(not(windows))]
-            return Err(BinaryNotInstalled(tool));
         }
     }
 
-    Ok(())
+    if let Some(found_binary) = found_binary {
+        Ok(found_binary)
+    } else {
+        Err(BinaryNotInstalled(binary))
+    }
 }

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -73,6 +73,21 @@ pub(crate) enum Error {
     )]
     BinaryNotInstalled(String),
 
+    #[error(
+        "Ambiguous binary specified while in strict mode. This is an unexpected error as no \
+        valid products have duplicated binaries. Please report this. \n
+        \n
+        Ambiguous binaries: {}\n
+        \n
+        To work around this, pass one of the absolute paths to the command and disable strict mode.
+    ", .0.iter().map(|v| format!("{}", v.display())).collect::<Vec<_>>().join(", "))]
+    BinaryAmbiguous(Vec<PathBuf>),
+
+    #[error(
+        "Strict mode does not handle multi-component paths. Pass just a binary name, eg `rustc`."
+    )]
+    StrictModeDoesNotAcceptPaths,
+
     // This is not *technically* needed, but it provides useful insights when an error happens when
     // invoking a binary proxy. Otherwise people could think the error comes from rustc/cargo/etc.
     #[error("criticalup could not invoke the binary you requested")]

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -62,7 +62,7 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
         } => commands::install::run(&ctx, reinstall, offline, project).await?,
         Commands::Clean => commands::clean::run(&ctx).await?,
         Commands::Remove { project } => commands::remove::run(&ctx, project).await?,
-        Commands::Run { command, project } => commands::run::run(&ctx, command, project).await?,
+        Commands::Run { command, project, strict } => commands::run::run(&ctx, command, project, strict).await?,
         Commands::Verify { project, offline } => {
             commands::verify::run(&ctx, project, offline).await?
         }
@@ -163,6 +163,10 @@ enum Commands {
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,
+
+        /// Only execute the specified binary if it is part of the installation
+        #[arg(long)]
+        strict: bool,
     },
 
     /// Delete all the products specified in the manifest `criticalup.toml`

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -62,7 +62,11 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
         } => commands::install::run(&ctx, reinstall, offline, project).await?,
         Commands::Clean => commands::clean::run(&ctx).await?,
         Commands::Remove { project } => commands::remove::run(&ctx, project).await?,
-        Commands::Run { command, project, strict } => commands::run::run(&ctx, command, project, strict).await?,
+        Commands::Run {
+            command,
+            project,
+            strict,
+        } => commands::run::run(&ctx, command, project, strict).await?,
         Commands::Verify { project, offline } => {
             commands::verify::run(&ctx, project, offline).await?
         }

--- a/crates/criticalup-cli/tests/cli/run.rs
+++ b/crates/criticalup-cli/tests/cli/run.rs
@@ -38,7 +38,7 @@ async fn simple_run_command_missing_package() {
     std::fs::write(&manifest, project_manifest.as_bytes()).unwrap();
     assert_output!(test_env
         .cmd()
-        .args(["run", "--project", manifest.to_str().unwrap(), "rustc"]));
+        .args(["run", "--strict", "--project", manifest.to_str().unwrap(), "rustc"]));
 }
 
 #[tokio::test]

--- a/crates/criticalup-cli/tests/cli/run.rs
+++ b/crates/criticalup-cli/tests/cli/run.rs
@@ -36,9 +36,13 @@ async fn simple_run_command_missing_package() {
         packages = [\"sample\"]
         ";
     std::fs::write(&manifest, project_manifest.as_bytes()).unwrap();
-    assert_output!(test_env
-        .cmd()
-        .args(["run", "--strict", "--project", manifest.to_str().unwrap(), "rustc"]));
+    assert_output!(test_env.cmd().args([
+        "run",
+        "--strict",
+        "--project",
+        manifest.to_str().unwrap(),
+        "rustc"
+    ]));
 }
 
 #[tokio::test]

--- a/crates/criticalup-cli/tests/snapshots/cli__run__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__help_message.snap
@@ -18,6 +18,7 @@ Arguments:
 
 Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`
+      --strict                      Only execute the specified binary if it is part of the installation
   -v, --verbose...                  Enable debug logs, -vv for trace
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help

--- a/crates/criticalup-cli/tests/snapshots/cli__run__simple_run_command_manifest_not_found.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__simple_run_command_manifest_not_found.snap
@@ -8,6 +8,7 @@ empty stdout
 
 stderr
 ------
-error: Failed to find canonical path for /path/to/criticalup.toml.
+error: Failed to load the project manifest at /path/to/criticalup.toml.
+  caused by: Failed to read the file.
   caused by: No such file or directory (os error 2)
 ------


### PR DESCRIPTION
Currently `criticalup run` can be used  to invoke different binary proxies, which are themselves `criticalup` in disguise. Then, those disguised `criticalup` instances go and replace-exec the correct binary from the project themselves.

Along the way, it manipulates the user's `$PATH` (or equivalent on other OS):

https://github.com/ferrocene/criticalup/blob/0624bcc2399617fea15e50596d09de17341274ee/crates/criticalup-cli/src/binary_proxies.rs#L77-L93

A consequence of this strategy means running `criticalup run $TOOL` where `$TOOL` is not part of the `criticalup.toml` results in an error:

```bash
$ criticalup run hyperfine
error: 'hyperfine' is not installed for this project.

Please make sure that the correct package for 'hyperfine' is listed in the packages section of your project's criticalup.toml and run 'criticalup install' command again.
```

This is in contrast to the behavor seen in, for example, in `uv`:

```bash
$ uv run cargo --version
cargo 1.83.0 (5ffbef321 2024-10-29)
```

Or `rustup`:

```bash
$ rustup run stable hyperfine --version
hyperfine 1.19.0
```

This PR rethinks that strategy, mostly inspired by using these tools. With this PR, `criticalup run` skips the execution of the binary proxies, then manipulates the path as needed before doing an exec-replace on the target command. This means the command the user runs does not necessarily need to be part of their `criticalup.toml`.

It means this is valid:

```bash
$ target/release/criticalup run hyperfine --version
hyperfine 1.19.0
```


## Performance

The current strategy doesn't take long:

```
(main) $ hyperfine "target/release/criticalup run rustc --version"
Benchmark 1: target/release/criticalup run rustc --version
  Time (mean ± σ):      29.7 ms ±   1.0 ms    [User: 9.1 ms, System: 30.5 ms]
  Range (min … max):    28.2 ms …  34.6 ms    84 runs
```

This strategy is measurably faster, but the difference is minor:

```
(changed) $ hyperfine "target/release/criticalup run rustc --version"
Benchmark 1: target/release/criticalup run rustc --version
  Time (mean ± σ):      22.2 ms ±   1.2 ms    [User: 7.2 ms, System: 19.7 ms]
  Range (min … max):    20.6 ms …  29.4 ms    125 runs
```

## Open questions

**Question:** Is this a feature we want? (Should `criticalup run` interact with non-managed binaries?)

Consideration: Users can always clear their `PATH` (or equivalent) variable before running:

```
$ PATH="" target/release/criticalup run rustc --version
rustc 1.81.0 (ff44b0db3 2024-11-25) (Ferrocene by Ferrous Systems)
```

```
$ LD_LIBRARY_PATH="" PATH="" target/release/criticalup run cargo build
   Compiling criticaltrust v0.4.0 (/home/ana/git/ferrocene/criticalup/crates/criticaltrust)
   Compiling criticalup-core v0.0.0 (/home/ana/git/ferrocene/criticalup/crates/criticalup-core)
   Compiling criticalup-cli v1.2.0 (/home/ana/git/ferrocene/criticalup/crates/criticalup-cli)
   Compiling criticalup v1.2.0 (/home/ana/git/ferrocene/criticalup/crates/criticalup)
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)

error: could not compile `criticalup` (bin "criticalup") due to 1 previous error
```