### PR TITLE
Environment Variable for Authentication Token Refactor

### DIFF
--- a/crates/criticalup-cli/src/commands/auth_remove.rs
+++ b/crates/criticalup-cli/src/commands/auth_remove.rs
@@ -8,7 +8,7 @@ use criticalup_core::state::{EnvVars, State};
 pub(crate) async fn run(ctx: &Context) -> Result<(), Error> {
     let state = State::load(&ctx.config).await?;
 
-    let env_vars = EnvVars::default();
+    let env_vars = EnvVars::read().await?;
 
     if state.authentication_token(None, &env_vars).await.is_some() {
         state.set_authentication_token(None);

--- a/crates/criticalup-cli/src/commands/auth_remove.rs
+++ b/crates/criticalup-cli/src/commands/auth_remove.rs
@@ -3,12 +3,14 @@
 
 use crate::errors::Error;
 use crate::Context;
-use criticalup_core::state::State;
+use criticalup_core::state::{EnvVars, State};
 
 pub(crate) async fn run(ctx: &Context) -> Result<(), Error> {
     let state = State::load(&ctx.config).await?;
 
-    if state.authentication_token(None).await.is_some() {
+    let env_vars = EnvVars::default();
+
+    if state.authentication_token(None, &env_vars).await.is_some() {
         state.set_authentication_token(None);
         state.persist().await?;
     }

--- a/crates/criticalup-cli/src/commands/auth_remove.rs
+++ b/crates/criticalup-cli/src/commands/auth_remove.rs
@@ -8,7 +8,7 @@ use criticalup_core::state::{EnvVars, State};
 pub(crate) async fn run(ctx: &Context) -> Result<(), Error> {
     let state = State::load(&ctx.config).await?;
 
-    let env_vars = EnvVars::read().await?;
+    let env_vars = EnvVars::default();
 
     if state.authentication_token(None, &env_vars).await.is_some() {
         state.set_authentication_token(None);

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -3,6 +3,7 @@
 
 use crate::config::Config;
 use crate::errors::{DownloadServerError, Error};
+use crate::state;
 use crate::state::State;
 use criticaltrust::keys::PublicKey;
 use criticaltrust::manifests::ReleaseManifest;
@@ -124,9 +125,11 @@ impl DownloadServerClient {
             None
         };
 
+        let env_vars = state::EnvVars::default();
+
         let header = self
             .state
-            .authentication_token(path_to_token_file)
+            .authentication_token(path_to_token_file, &env_vars)
             .await
             .as_ref()
             .and_then(|token| HeaderValue::from_str(&format!("Bearer {}", token.unseal())).ok());

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -125,7 +125,7 @@ impl DownloadServerClient {
             None
         };
 
-        let env_vars = state::EnvVars::read().await?;
+        let env_vars = state::EnvVars::default();
 
         let header = self
             .state

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -125,7 +125,7 @@ impl DownloadServerClient {
             None
         };
 
-        let env_vars = state::EnvVars::default();
+        let env_vars = state::EnvVars::read().await?;
 
         let header = self
             .state

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -4,6 +4,7 @@
 use criticaltrust::Error as TrustError;
 use reqwest::Error as ReqError;
 use reqwest::StatusCode;
+use std::env::VarError;
 use std::path::PathBuf;
 
 /// We're using a custom error enum instead of `Box<dyn Error>` or one of the crates providing a
@@ -95,6 +96,13 @@ pub enum Error {
 
     #[error("Failed to load keys into keychain.")]
     KeychainLoadingFailed(#[source] criticaltrust::Error),
+
+    #[error("Environment variable '{}' is not UTF-8 encoded.", name)]
+    EnvVarNotUtf8 {
+        name: String,
+        #[source]
+        kind: VarError,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/criticalup-core/src/state.rs
+++ b/crates/criticalup-core/src/state.rs
@@ -1052,7 +1052,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_authn_token_env_var() {
+    async fn test_set_auth_token_env_var() {
         let test_env = TestEnvironment::with().state().prepare().await;
         let state = test_env.state();
 


### PR DESCRIPTION
For important environment variables like `CRITICALUP_TOKEN` we should use a separate struct as a technique so as to avoid having to call `std::env::var` at multiple places. This can help with localizing errors and testing.

This does not change any functionality.