### PR TITLE
Improve naming consistency - command arguments

### DIFF
--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -71,7 +71,7 @@ async fn main_inner(whitelabel: WhitelabelConfig, args: &[OsString]) -> Result<(
             commands::verify::run(&ctx, project, offline).await?
         }
         Commands::Which {
-            binary: tool,
+            command: tool,
             project,
         } => commands::which::run(&ctx, tool, project).await?,
         Commands::Archive {
@@ -195,7 +195,7 @@ enum Commands {
     /// Display which binary will be run for a given command
     Which {
         /// Name of the binary to find the absolute path of
-        binary: String,
+        command: String,
         /// Path to the manifest `criticalup.toml`
         #[arg(long)]
         project: Option<PathBuf>,

--- a/crates/criticalup-cli/tests/snapshots/cli__which__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__which__help_message.snap
@@ -11,10 +11,10 @@ stderr
 Display which binary will be run for a given command
 
 Usage:
-  criticalup-test which [OPTIONS] <BINARY>
+  criticalup-test which [OPTIONS] <COMMAND>
 
 Arguments:
-  <BINARY>  Name of the binary to find the absolute path of
+  <COMMAND>  Name of the binary to find the absolute path of
 
 Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`


### PR DESCRIPTION
Note: to be done after #80 

Changes `criticalup which` to `<COMMAND>` instead of `<BINARY>` to be consistent with the `criticalup run` command.

