### PR TITLE
Naming consistency for arguments of subcommands.

### DIFF
--- a/crates/criticalup-cli/src/cli/subcommand/which.rs
+++ b/crates/criticalup-cli/src/cli/subcommand/which.rs
@@ -15,7 +15,7 @@ use tracing::Span;
 #[derive(Debug, Parser)]
 pub(crate) struct Which {
     /// Name of the binary to find the absolute path of
-    binary: String,
+    command: String,
     /// Path to the manifest `criticalup.toml`
     #[arg(long)]
     project: Option<PathBuf>,
@@ -41,7 +41,7 @@ impl CommandExecute for Which {
             let bin_path = PathBuf::from("bin");
 
             let mut tool_executable = PathBuf::new();
-            tool_executable.set_file_name(&self.binary);
+            tool_executable.set_file_name(&self.command);
 
             let tools_bin_path = abs_installation_dir_path.join(bin_path.join(&tool_executable));
 
@@ -60,7 +60,7 @@ impl CommandExecute for Which {
                     }
                 }
                 #[cfg(not(windows))]
-                return Err(BinaryNotInstalled(self.binary));
+                return Err(BinaryNotInstalled(self.command));
             }
         }
 

--- a/crates/criticalup-cli/tests/snapshots/cli__which__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__which__help_message.snap
@@ -11,10 +11,10 @@ stderr
 Display which binary will be run for a given command
 
 Usage:
-  criticalup-test which [OPTIONS] <BINARY>
+  criticalup-test which [OPTIONS] <COMMAND>
 
 Arguments:
-  <BINARY>  Name of the binary to find the absolute path of
+  <COMMAND>  Name of the binary to find the absolute path of
 
 Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`


### PR DESCRIPTION
Make `which` subcommand use the same term as `run`.