### PR TITLE
Revert "Release v1.4.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.0] - 2025-03-04
+## [Unreleased]
 
 ### Fixed
 
@@ -99,9 +99,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.4.0...HEAD
-
-[1.4.0]:  https://github.com/ferrocene/criticalup/compare/v1.3.0...1.4.0
+[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.3.0...HEAD
 
 [1.3.0]: https://github.com/ferrocene/criticalup/compare/v1.2.0...v1.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup"
-version = "1.4.0"
+version = "1.3.0"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-cli"
-version = "1.4.0"
+version = "1.3.0"
 dependencies = [
  "clap",
  "criticaltrust",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-dev"
-version = "1.4.0"
+version = "1.3.0"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-cli"
-version = "1.4.0"
+version = "1.3.0"
 edition = "2021"
 repository = "https://github.com/ferrocene/criticalup"
 homepage = "https://github.com/ferrocene/criticalup"

--- a/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
@@ -8,5 +8,5 @@ empty stdout
 
 stderr
 ------
-criticalup-test 1.4.0
+criticalup-test 1.3.0
 ------

--- a/crates/criticalup-dev/Cargo.toml
+++ b/crates/criticalup-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-dev"
-version = "1.4.0"
+version = "1.3.0"
 edition = "2021"
 publish = false
 

--- a/crates/criticalup/Cargo.toml
+++ b/crates/criticalup/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup"
-version = "1.4.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["The CriticalUp Developers"]
 description = "Ferrocene toolchain manager"


### PR DESCRIPTION
This reverts commit 23b7de3cdbf13b073eac9084f08b5cd06e1702ef.

We will open a new release/v1.4.0 soon after this is merged to have a better synchronized release.