### PR TITLE
Add log format options, turn on more tracing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 [build]
-rustflags = ["--cfg", "hyper_unstable_tracing"]
+rustflags = ["--cfg", "hyper_unstable_tracing", "--cfg", "tokio_unstable"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: The Ferrocene Developers
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
+[build]
+rustflags = ["--cfg", "hyper_unstable_tracing"]
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
 - Added a 90 second connect/idle timeouts in the download client, which should reduce the risk of long hangs
   in exotic networking situations.
 
+### Added
+
+- Added a `--log-format $FORMAT` flag, with the options of `default`, `pretty`, and `json`.
+  The `default` option preserves existing behavior, while `pretty` shows the previous `--verbose` format,
+  `json` outputs as JSON.
+
 ## [1.4.0] - 2025-03-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "criticalup-core",
  "dirs",
  "futures",
+ "hyper 1.6.0",
  "insta",
  "mock-download-server",
  "opener",
@@ -1474,6 +1475,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "tracing",
  "want",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 walkdir = "2"
 xz2 = "0.1.7"
+hyper = { version = "1", features = ["tracing"] }
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tar = "0.4.44"
 tempfile = "3"
 thiserror = "2.0.12"
 time = { version = "0.3.41", features = ["std", "serde", "serde-well-known", "macros"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "process"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "process", "tracing"] }
 toml_edit = { version = "0.22.24", features = ["serde"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/crates/criticaltrust/Cargo.toml
+++ b/crates/criticaltrust/Cargo.toml
@@ -23,12 +23,12 @@ serde_with.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 time.workspace = true
-tokio = { version = "1.44.1", features = ["rt", "rt-multi-thread", "macros"], optional = true }
+tokio = { workspace = true, optional = true }
 reqwest.workspace = true
 
 [dev-dependencies]
 itertools = "0.14.0"
-tokio = { version = "1.44.1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio.workspace = true
 
 [features]
 aws-kms = ["aws-sdk-kms", "aws-config", "aws-smithy-runtime-api", "tokio"]

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber.workspace = true
 url = "2.5.4"
 walkdir.workspace = true
 xz2.workspace = true
+hyper.workspace = true
 
 [dev-dependencies]
 dirs.workspace = true

--- a/crates/criticalup-cli/src/cli/instrumentation.rs
+++ b/crates/criticalup-cli/src/cli/instrumentation.rs
@@ -19,7 +19,7 @@ pub(crate) struct Instrumentation {
         conflicts_with = "log_level",
     )]
     pub(crate) verbose: u8,
-    /// Which logger to use (options are `compact`, `full`, `pretty`, and `json`)
+    /// Which logger to use
     #[clap(long, default_value_t = Default::default(), global = true)]
     pub log_format: Logger,
     /// Tracing directives

--- a/crates/criticalup-cli/src/cli/instrumentation.rs
+++ b/crates/criticalup-cli/src/cli/instrumentation.rs
@@ -19,6 +19,9 @@ pub(crate) struct Instrumentation {
         conflicts_with = "log_level",
     )]
     pub(crate) verbose: u8,
+    /// Which logger to use (options are `compact`, `full`, `pretty`, and `json`)
+    #[clap(long, default_value_t = Default::default(), global = true)]
+    pub log_format: Logger,
     /// Tracing directives
     #[clap(long, global = true, group = "verbosity", value_delimiter = ',', num_args = 0.., conflicts_with = "verbose")]
     pub(crate) log_level: Vec<Directive>,
@@ -37,39 +40,29 @@ impl Instrumentation {
     pub(crate) async fn setup(&self, binary_name: &str) -> Result<(), crate::Error> {
         let filter_layer = self.filter_layer(binary_name)?;
 
-        if self.verbose != 0 {
-            let fmt_layer = self.verbose_fmt_layer();
-            tracing_subscriber::registry()
-                .with(filter_layer)
-                .with(fmt_layer)
-                .try_init()?;
-        } else {
-            let fmt_layer = self.fmt_layer();
-            tracing_subscriber::registry()
-                .with(filter_layer)
-                .with(fmt_layer)
-                .try_init()?;
-        }
+        let registry = tracing_subscriber::registry().with(filter_layer);
 
+        match self.log_format {
+            Logger::Default => {
+                let fmt_layer = self.default_fmt_layer();
+                registry.with(fmt_layer).try_init()?
+            }
+            Logger::Pretty => {
+                let fmt_layer = self.pretty_fmt_layer();
+                registry.with(fmt_layer).try_init()?
+            }
+            Logger::Json => {
+                let fmt_layer = self.json_fmt_layer();
+                registry.with(fmt_layer).try_init()?
+            }
+        }
         tracing::trace!("Instrumentation initialized");
 
         Ok(())
     }
 
-    /// Set up a 'pretty' formatter that displays structure span information, timestamps,
-    /// line numbers/files, etc.
-    pub(crate) fn verbose_fmt_layer<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
-    where
-        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
-    {
-        tracing_subscriber::fmt::Layer::new()
-            .with_ansi(std::io::stderr().is_terminal())
-            .with_writer(std::io::stderr)
-            .pretty()
-    }
-
     /// Set up a basic, simple logger that doesn't emit more than it needs.
-    pub(crate) fn fmt_layer<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    pub(crate) fn default_fmt_layer<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
     where
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
@@ -80,6 +73,29 @@ impl Instrumentation {
             .with_file(self.verbose != 0)
             .with_line_number(self.verbose != 0)
             .with_target(self.verbose != 0)
+    }
+
+    /// Set up a 'pretty' formatter that displays structure span information, timestamps,
+    /// line numbers/files, etc.
+    pub(crate) fn pretty_fmt_layer<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::Layer::new()
+            .with_ansi(std::io::stderr().is_terminal())
+            .with_writer(std::io::stderr)
+            .pretty()
+    }
+
+    /// Set up a JSON formatter for machine parseable output    
+    pub fn json_fmt_layer<S>(&self) -> impl tracing_subscriber::layer::Layer<S>
+    where
+        S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    {
+        tracing_subscriber::fmt::Layer::new()
+            .with_ansi(std::io::stderr().is_terminal())
+            .with_writer(std::io::stderr)
+            .json()
     }
 
     pub(crate) fn filter_layer(&self, binary_name: &str) -> Result<EnvFilter, crate::Error> {
@@ -101,5 +117,24 @@ impl Instrumentation {
         }
 
         Ok(filter_layer)
+    }
+}
+
+#[derive(Clone, Default, Debug, clap::ValueEnum)]
+pub enum Logger {
+    #[default]
+    Default,
+    Pretty,
+    Json,
+}
+
+impl std::fmt::Display for Logger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let logger = match self {
+            Logger::Default => "default",
+            Logger::Pretty => "pretty",
+            Logger::Json => "json",
+        };
+        write!(f, "{}", logger)
     }
 }

--- a/crates/criticalup-cli/tests/snapshots/cli__auth__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__auth__help_message.snap
@@ -20,6 +20,7 @@ Commands:
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__auth_remove__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__auth_remove__help_message.snap
@@ -15,6 +15,7 @@ Usage:
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__auth_set__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__auth_set__help_message.snap
@@ -18,6 +18,7 @@ Arguments:
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__clean__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__clean__help_message.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/criticalup-cli/tests/cli/clean.rs
 expression: repr
-snapshot_kind: text
 ---
 exit: exit status: 0
 
@@ -16,6 +15,7 @@ Usage:
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__doc__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__doc__help_message.snap
@@ -17,6 +17,7 @@ Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`
       --path                        Only print the path to the documentation location
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__init__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__init__help_message.snap
@@ -17,6 +17,7 @@ Options:
       --release <RELEASE>           Release version of Ferrocene from https://releases.ferrocene.dev/ferrocene/index.html
       --print                       Only print the contents of manifest instead of saving to file
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__install__help_message.snap
@@ -18,6 +18,7 @@ Options:
       --reinstall                   Reinstall products that may have already been installed
       --offline                     Don't download from the server, only use previously cached artifacts
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__remove__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__remove__help_message.snap
@@ -16,6 +16,7 @@ Usage:
 Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__no_args.snap
@@ -28,6 +28,7 @@ Commands:
 
 Options:
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
   -V, --version                     Print version

--- a/crates/criticalup-cli/tests/snapshots/cli__run__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__help_message.snap
@@ -20,6 +20,7 @@ Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`
       --strict                      Only execute the specified binary if it is part of the installation
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------

--- a/crates/criticalup-cli/tests/snapshots/cli__which__help_message.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__which__help_message.snap
@@ -19,6 +19,7 @@ Arguments:
 Options:
       --project <PROJECT>           Path to the manifest `criticalup.toml`
   -v, --verbose...                  Enable debug logs, -vv for trace
+      --log-format <LOG_FORMAT>     Which logger to use [default: default] [possible values: default, pretty, json]
       --log-level [<LOG_LEVEL>...]  Tracing directives
   -h, --help                        Print help
 ------


### PR DESCRIPTION
Let users pass `--log-format $FORMAT` to define what format of logs to get, also allow users to turn on `hyper`'s tracing logs if they want.

Take it for a spin with like:

```
cargo run -- install --log-level "hyper=trace" --reinstall --log-format pretty
```

Or 

```
cargo run -- install --log-level "hyper=trace,reqwest=trace,criticalup-cli=warn" --reinstall --log-format json
```