### PR TITLE
Add some timeouts to our download client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Changed
+
+- Added a 90 second connect/idle timeouts in the download client, which should reduce the risk of long hangs
+  in exotic networking situations.
+
 ## [1.4.0] - 2025-03-05
 
 ### Fixed

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::time::Duration;
+
 use crate::config::Config;
 use crate::envvars;
 use crate::errors::{DownloadServerError, Error};
@@ -31,6 +33,9 @@ impl DownloadServerClient {
         let retry_policy = ExponentialBackoff::builder().build_with_max_retries(CLIENT_MAX_RETRIES);
         let client = reqwest::ClientBuilder::new()
             .user_agent(config.whitelabel.http_user_agent)
+            .read_timeout(Duration::from_secs(90))
+            .connect_timeout(Duration::from_secs(90))
+            .pool_idle_timeout(Duration::from_secs(90))
             .build()
             .expect("failed to configure http client");
         let client = ClientBuilder::new(client)

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -36,6 +36,10 @@ impl DownloadServerClient {
             .read_timeout(Duration::from_secs(90))
             .connect_timeout(Duration::from_secs(90))
             .pool_idle_timeout(Duration::from_secs(90))
+            // In rare cases we were encountering a hang in networking in Docker-in-Docker
+            // `docker buildx build` situations. This workaround seems to help.
+            // ref: https://github.com/hyperium/hyper/issues/2312#issuecomment-778005053
+            .pool_max_idle_per_host(0)
             .build()
             .expect("failed to configure http client");
         let client = ClientBuilder::new(client)


### PR DESCRIPTION
Adds around 90s of timeout to connection/read idle to hopefully catch any hung downloads in exotic networking situations.