### PR TITLE
Remove docker secret detection/integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 - Added a 90 second connect/idle timeouts in the download client, which should reduce the risk of long hangs
   in exotic networking situations.
+- Removed an experimental feature that attempted to integrate with Docker secrets. After more testing,
+  our team was unsatisfied with it's behavior and opted not to mature it.
 
 ## [1.4.0] - 2025-03-05
 

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use crate::config::Config;
 use crate::envvars;
 use crate::errors::{DownloadServerError, Error};
-use crate::state::{AuthenticationToken, State};
+use crate::state::State;
 use criticaltrust::keys::PublicKey;
 use criticaltrust::manifests::ReleaseManifest;
 use criticaltrust::manifests::{KeysManifest, ReleaseArtifactFormat};


### PR DESCRIPTION
After some testing I both:

* Don't think this worked right
* Don't think it was particularly useful, and was instead rather surprising.

It wasn't documented, so I just removed it.