### PR TITLE
Tune some output, expand on binary proxy tracing

### DIFF
--- a/crates/criticalup-cli/src/cli/instrumentation.rs
+++ b/crates/criticalup-cli/src/cli/instrumentation.rs
@@ -4,7 +4,7 @@
 use std::io::IsTerminal;
 
 use tracing_subscriber::{
-    filter::Directive, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+    filter::Directive, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter
 };
 
 #[derive(clap::Args, Debug)]
@@ -67,12 +67,11 @@ impl Instrumentation {
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
         tracing_subscriber::fmt::Layer::new()
+            .compact()
             .with_ansi(std::io::stderr().is_terminal())
             .with_writer(std::io::stderr)
             .without_time()
-            .with_file(self.verbose != 0)
-            .with_line_number(self.verbose != 0)
-            .with_target(self.verbose != 0)
+            .with_target(self.verbose >= 2)
     }
 
     /// Set up a 'pretty' formatter that displays structure span information, timestamps,

--- a/crates/criticalup-cli/src/cli/instrumentation.rs
+++ b/crates/criticalup-cli/src/cli/instrumentation.rs
@@ -4,7 +4,7 @@
 use std::io::IsTerminal;
 
 use tracing_subscriber::{
-    filter::Directive, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter
+    filter::Directive, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
 };
 
 #[derive(clap::Args, Debug)]

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -22,7 +22,7 @@ use crate::state::State;
 ///   `proxy_binary`, to ensure they all point to the latest available version. This is likely to
 ///   occur after the user updates criticalup.
 ///
-#[tracing::instrument(skip_all, fields(
+#[tracing::instrument(level = "trace", skip_all, fields(
     proxy_binary = %proxy_binary.display()
 ))]
 pub async fn update(
@@ -41,7 +41,7 @@ pub async fn update(
         .into_iter()
         .collect::<HashSet<_>>();
 
-    tracing::debug!(
+    tracing::trace!(
         expected_proxies = expected_proxies.len(),
         "Updating binary proxies"
     );
@@ -119,7 +119,7 @@ async fn ensure_link(proxy_binary: &Path, target: &Path) -> Result<(), BinaryPro
 
         tracing::debug!(target = %target.display(), "Created binary proxy");
     } else {
-        tracing::debug!(target = %target.display(), "Skipped creating binary proxy, already exists");
+        tracing::trace!(target = %target.display(), "Skipped creating binary proxy, already exists");
     }
 
     Ok(())
@@ -159,6 +159,8 @@ async fn ensure_link(proxy_binary: &Path, target: &Path) -> Result<(), BinaryPro
         }
     })?;
 
+    tracing::debug!(target = %target.display(), "Created binary proxy");
+
     Ok(())
 }
 
@@ -170,7 +172,7 @@ async fn remove_unexpected(path: &Path) -> Result<(), BinaryProxyUpdateError> {
     };
     match result {
         Ok(()) => {
-            tracing::trace!(path = %path.display(), "Removed unexpected binary proxy");
+            tracing::trace!(path = %path.display(), "Removed binary proxy");
             Ok(())
         }
         Err(err) => Err(BinaryProxyUpdateError::UnexpectedPathRemovalFailed(

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -22,6 +22,9 @@ use crate::state::State;
 ///   `proxy_binary`, to ensure they all point to the latest available version. This is likely to
 ///   occur after the user updates criticalup.
 ///
+#[tracing::instrument(skip_all, fields(
+    proxy_binary = %proxy_binary.display()
+))]
 pub async fn update(
     config: &Config,
     state: &State,
@@ -37,6 +40,11 @@ pub async fn update(
         .all_binary_proxy_names()
         .into_iter()
         .collect::<HashSet<_>>();
+
+    tracing::debug!(
+        expected_proxies = expected_proxies.len(),
+        "Updating binary proxies"
+    );
 
     let dir = &config.paths.proxies_dir;
     let list_dir_error = |e| BinaryProxyUpdateError::ListDirectoryFailed(dir.into(), e);
@@ -58,9 +66,13 @@ pub async fn update(
         Err(err) => return Err(list_dir_error(err)),
     }
 
-    for proxy in expected_proxies {
-        let target = &config.paths.proxies_dir.join(&proxy);
-        ensure_link(proxy_binary, target).await?;
+    if expected_proxies.is_empty() {
+        tracing::trace!("No new proxies to create")
+    } else {
+        for proxy in expected_proxies {
+            let target = &config.paths.proxies_dir.join(&proxy);
+            ensure_link(proxy_binary, target).await?;
+        }
     }
 
     Ok(())
@@ -104,6 +116,10 @@ async fn ensure_link(proxy_binary: &Path, target: &Path) -> Result<(), BinaryPro
                 inner: e,
             }
         })?;
+
+        tracing::debug!(target = %target.display(), "Created binary proxy");
+    } else {
+        tracing::debug!(target = %target.display(), "Skipped creating binary proxy, already exists");
     }
 
     Ok(())
@@ -153,7 +169,10 @@ async fn remove_unexpected(path: &Path) -> Result<(), BinaryProxyUpdateError> {
         tokio::fs::remove_file(path).await
     };
     match result {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            tracing::trace!(path = %path.display(), "Removed unexpected binary proxy");
+            Ok(())
+        }
         Err(err) => Err(BinaryProxyUpdateError::UnexpectedPathRemovalFailed(
             path.into(),
             err,

--- a/crates/criticalup-core/src/download_server_cache.rs
+++ b/crates/criticalup-core/src/download_server_cache.rs
@@ -56,7 +56,7 @@ impl<'a> DownloadServerCache<'a> {
 
     /// Return the path to a package which either already existed in the cache, or is freshly
     /// downloaded.
-    #[tracing::instrument(level = "debug", skip_all, fields(
+    #[tracing::instrument(level = "trace", skip_all, fields(
         %product,
         %release,
         %package,
@@ -99,7 +99,7 @@ impl<'a> DownloadServerCache<'a> {
         Ok(cache_key)
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
+    #[tracing::instrument(level = "trace", skip_all, fields(
         %product,
         %release,
     ))]
@@ -147,7 +147,7 @@ impl<'a> DownloadServerCache<'a> {
         Ok(data)
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn keys(&self) -> Result<Keychain, Error> {
         let cache_key = self.keys_path();
 

--- a/crates/criticalup-core/src/download_server_client.rs
+++ b/crates/criticalup-core/src/download_server_client.rs
@@ -62,7 +62,7 @@ impl DownloadServerClient {
         .await
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn get_keys(&self) -> Result<Keychain, Error> {
         let resp: KeysManifest = self
             .json(self.send(self.client.get(self.url("/v1/keys"))).await?)
@@ -72,7 +72,7 @@ impl DownloadServerClient {
         Ok(keychain)
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
+    #[tracing::instrument(level = "trace", skip_all, fields(
         %product,
         %release,
     ))]
@@ -89,7 +89,7 @@ impl DownloadServerClient {
         .await
     }
 
-    #[tracing::instrument(level = "debug", skip_all, fields(
+    #[tracing::instrument(level = "trace", skip_all, fields(
         %product,
         %release,
         %package,

--- a/crates/criticalup-core/src/state.rs
+++ b/crates/criticalup-core/src/state.rs
@@ -195,7 +195,7 @@ impl State {
 
         let mut all_proxies = vec![];
         for (id, installation) in &state.repr.installations {
-            let span = span!(Level::TRACE, "all_binary_proxy_names::installation", %id);
+            let span = span!(Level::TRACE, "installation", %id);
             let _entered = span.enter();
 
             let installation_proxies = &installation.binary_proxies;


### PR DESCRIPTION
Try to tune up the default logger a bit, add some extra tracing to binary proxies while I investigated a puzzle. (I was using `criticalup` and editing the `criticalup-dev` config...)

![image](https://github.com/user-attachments/assets/b82f449a-da9b-472b-9bd8-88e515501bf5)
