### PR TITLE
Support `rustup toolchain link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
   in exotic networking situations.
 - Removed an experimental feature that attempted to integrate with Docker secrets. After more testing,
   our team was unsatisfied with it's behavior and opted not to mature it.
+- Altered the location of the binary proxies to enable clean integration with `rustup toolchain link`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ All notable changes to this project will be documented in this file.
 - Removed an experimental feature that attempted to integrate with Docker secrets. After more testing,
   our team was unsatisfied with it's behavior and opted not to mature it.
 - Altered the location of the binary proxies to enable clean integration with `rustup toolchain link`.
+  Previously, binary proxies were in the `bin/` folder of the CriticalUp home, now they are in `proxy/bin/`.
 
 ### Added
 
 - Added a `--log-format $FORMAT` flag, with the options of `default`, `pretty`, `tree`, and `json`.
   The `default` option preserves existing behavior, while `pretty` shows the previous `--verbose` format,
   `json` outputs as JSON, and `tree` displays logging span structure.
+- Added support registering the CriticalUp binary proxies as a `rustup` toolchain. You can now run
+  `rustup toolchain link $TOOLCHAIN` (OS dependent, see docs) then use, for example, `cargo +ferrocene build`.
 
 ## [1.4.0] - 2025-03-05
 

--- a/crates/criticalup-cli/src/binary_proxies.rs
+++ b/crates/criticalup-cli/src/binary_proxies.rs
@@ -70,7 +70,13 @@ pub(crate) async fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
     // `PATH` themselves, but they:
     // 1) Shouldn't do that, and
     // 2) Can set `RUSTC` which `cargo` already supports.
-    let additional_bin_path = config.paths.proxies_dir.clone();
+    let additional_bin_path = config
+        .paths
+        .installation_dir
+        .clone()
+        .join(&installation_id)
+        .join("bin")
+        .clone();
     // We need to also set the library path according to
     // https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths
     // Notably: On Windows this is the same as the binary path.
@@ -78,7 +84,7 @@ pub(crate) async fn proxy(whitelabel: WhitelabelConfig) -> Result<(), Error> {
         .paths
         .installation_dir
         .clone()
-        .join(installation_id)
+        .join(&installation_id)
         .join("lib");
 
     #[cfg(target_os = "macos")]

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -95,7 +95,7 @@ async fn remove_deprecated_proxies(old: &PathBuf, new: &PathBuf) -> Result<(), B
     let old_bin_dir = old;
     if old_bin_dir.exists() {
         tracing::info!("Tidying deprecated binary proxies, they are now located at `{}`", new.join("bin").display());
-        tracing::info!("You can also now use `rustup toolchain link ferrocene {}` then use Ferrocene like any other Rust toolchain via `cargo +ferrocene build`", new.display());
+        tracing::info!("You can also now use `rustup toolchain link ferrocene \"{}\"` then use Ferrocene like any other Rust toolchain via `cargo +ferrocene build`", new.display());
         tokio::fs::remove_dir_all(&old_bin_dir).await.map_err(|e| BinaryProxyUpdateError::DirectoryRemovalFailed(old_bin_dir.clone(), e))?;
     }
     Ok(())

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -91,12 +91,20 @@ pub async fn update(
 }
 
 // Previously, proxies were located at `root/bin`, now they are at `root/proxy/bin`, remove any remains.
-async fn remove_deprecated_proxies(old: &PathBuf, new: &PathBuf) -> Result<(), BinaryProxyUpdateError> {
+async fn remove_deprecated_proxies(
+    old: &PathBuf,
+    new: &PathBuf,
+) -> Result<(), BinaryProxyUpdateError> {
     let old_bin_dir = old;
     if old_bin_dir.exists() {
-        tracing::info!("Tidying deprecated binary proxies, they are now located at `{}`", new.join("bin").display());
+        tracing::info!(
+            "Tidying deprecated binary proxies, they are now located at `{}`",
+            new.join("bin").display()
+        );
         tracing::info!("You can also now use `rustup toolchain link ferrocene \"{}\"` then use Ferrocene like any other Rust toolchain via `cargo +ferrocene build`", new.display());
-        tokio::fs::remove_dir_all(&old_bin_dir).await.map_err(|e| BinaryProxyUpdateError::DirectoryRemovalFailed(old_bin_dir.clone(), e))?;
+        tokio::fs::remove_dir_all(&old_bin_dir)
+            .await
+            .map_err(|e| BinaryProxyUpdateError::DirectoryRemovalFailed(old_bin_dir.clone(), e))?;
     }
     Ok(())
 }

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -41,7 +41,6 @@ pub async fn update(
         .into_iter()
         .collect::<HashSet<_>>();
 
-
     tracing::trace!(
         expected_proxies = expected_proxies.len(),
         "Updating binary proxies"

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -93,7 +93,7 @@ pub async fn update(
 // Previously, proxies were located at `root/bin`, now they are at `root/proxy/bin`, remove any remains.
 async fn remove_deprecated_proxies(
     old: &PathBuf,
-    new: &PathBuf,
+    new: &Path,
 ) -> Result<(), BinaryProxyUpdateError> {
     let old_bin_dir = old;
     if old_bin_dir.exists() {

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -57,7 +57,7 @@ pub async fn update(
         .map_err(|e| BinaryProxyUpdateError::DirectoryCreationFailed(bin_dir.clone(), e))?;
 
     // Migrate to new proxy system
-    remove_deprecated_proxies(&config.paths.root.join("bin"), bin_dir).await?;
+    remove_deprecated_proxies(&config.paths.root.join("bin"), &config.paths.proxy_dir).await?;
 
     let list_dir_error = |e| BinaryProxyUpdateError::ListDirectoryFailed(bin_dir.into(), e);
     match tokio::fs::read_dir(bin_dir).await {
@@ -94,8 +94,8 @@ pub async fn update(
 async fn remove_deprecated_proxies(old: &PathBuf, new: &PathBuf) -> Result<(), BinaryProxyUpdateError> {
     let old_bin_dir = old;
     if old_bin_dir.exists() {
-        tracing::info!("Tidying deprecated binary proxies, they are now located at `{}`", new.display());
-        tracing::info!("You can also now use `rustup toolchain link +ferrocene {}` then use Ferrocene like any other Rust toolchain via `cargo +ferrocene build`", new.display());
+        tracing::info!("Tidying deprecated binary proxies, they are now located at `{}`", new.join("bin").display());
+        tracing::info!("You can also now use `rustup toolchain link ferrocene {}` then use Ferrocene like any other Rust toolchain via `cargo +ferrocene build`", new.display());
         tokio::fs::remove_dir_all(&old_bin_dir).await.map_err(|e| BinaryProxyUpdateError::DirectoryRemovalFailed(old_bin_dir.clone(), e))?;
     }
     Ok(())

--- a/crates/criticalup-core/src/binary_proxies.rs
+++ b/crates/criticalup-core/src/binary_proxies.rs
@@ -41,14 +41,26 @@ pub async fn update(
         .into_iter()
         .collect::<HashSet<_>>();
 
+
     tracing::trace!(
         expected_proxies = expected_proxies.len(),
         "Updating binary proxies"
     );
 
-    let dir = &config.paths.proxies_dir;
-    let list_dir_error = |e| BinaryProxyUpdateError::ListDirectoryFailed(dir.into(), e);
-    match tokio::fs::read_dir(dir).await {
+    let bin_dir = &config.paths.proxy_dir.join("bin");
+    tokio::fs::create_dir_all(bin_dir)
+        .await
+        .map_err(|e| BinaryProxyUpdateError::DirectoryCreationFailed(bin_dir.clone(), e))?;
+    // Required for `rustup toolchain link`
+    tokio::fs::create_dir_all(config.paths.proxy_dir.join("lib"))
+        .await
+        .map_err(|e| BinaryProxyUpdateError::DirectoryCreationFailed(bin_dir.clone(), e))?;
+
+    // Migrate to new proxy system
+    remove_deprecated_proxies(&config.paths.root.join("bin"), bin_dir).await?;
+
+    let list_dir_error = |e| BinaryProxyUpdateError::ListDirectoryFailed(bin_dir.into(), e);
+    match tokio::fs::read_dir(bin_dir).await {
         Ok(mut iter) => {
             while let Some(entry) = iter.next_entry().await.map_err(list_dir_error)? {
                 let entry_name = PathBuf::from(entry.file_name());
@@ -70,11 +82,22 @@ pub async fn update(
         tracing::trace!("No new proxies to create")
     } else {
         for proxy in expected_proxies {
-            let target = &config.paths.proxies_dir.join(&proxy);
+            let target = &config.paths.proxy_dir.join("bin").join(&proxy);
             ensure_link(proxy_binary, target).await?;
         }
     }
 
+    Ok(())
+}
+
+// Previously, proxies were located at `root/bin`, now they are at `root/proxy/bin`, remove any remains.
+async fn remove_deprecated_proxies(old: &PathBuf, new: &PathBuf) -> Result<(), BinaryProxyUpdateError> {
+    let old_bin_dir = old;
+    if old_bin_dir.exists() {
+        tracing::info!("Tidying deprecated binary proxies, they are now located at `{}`", new.display());
+        tracing::info!("You can also now use `rustup toolchain link +ferrocene {}` then use Ferrocene like any other Rust toolchain via `cargo +ferrocene build`", new.display());
+        tokio::fs::remove_dir_all(&old_bin_dir).await.map_err(|e| BinaryProxyUpdateError::DirectoryRemovalFailed(old_bin_dir.clone(), e))?;
+    }
     Ok(())
 }
 
@@ -105,9 +128,9 @@ async fn ensure_link(proxy_binary: &Path, target: &Path) -> Result<(), BinaryPro
 
     if should_create {
         if let Some(parent) = target.parent() {
-            tokio::fs::create_dir_all(parent).await.map_err(|e| {
-                BinaryProxyUpdateError::ParentDirectoryCreationFailed(parent.into(), e)
-            })?;
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| BinaryProxyUpdateError::DirectoryCreationFailed(parent.into(), e))?;
         }
         std::os::unix::fs::symlink(proxy_binary, target).map_err(|e| {
             BinaryProxyUpdateError::SymlinkFailed {
@@ -143,7 +166,7 @@ async fn ensure_link(proxy_binary: &Path, target: &Path) -> Result<(), BinaryPro
     if let Some(parent) = target.parent() {
         tokio::fs::create_dir_all(parent)
             .await
-            .map_err(|e| BinaryProxyUpdateError::ParentDirectoryCreationFailed(parent.into(), e))?;
+            .map_err(|e| BinaryProxyUpdateError::DirectoryCreationFailed(parent.into(), e))?;
     }
 
     // We opt against symlinks on Windows. Many of our users are not on Windows 11 which does
@@ -303,7 +326,7 @@ mod tests {
             let expected_proxy_content = std::fs::read(expected_proxy).unwrap();
 
             let mut found_proxies = Vec::new();
-            for file in config.paths.proxies_dir.read_dir().unwrap() {
+            for file in config.paths.proxy_dir.join("bin").read_dir().unwrap() {
                 let file = file.unwrap().path();
                 found_proxies.push(file.file_name().unwrap().to_str().unwrap().to_string());
 
@@ -386,16 +409,16 @@ mod tests {
         let state = test_env.state();
 
         // If the directory does not exist, the `.is_dir()` method fails to recognize it's a dir.
-        tokio::fs::create_dir_all(&test_env.config().paths.proxies_dir)
+        tokio::fs::create_dir_all(&test_env.config().paths.proxy_dir.join("bin"))
             .await
             .unwrap();
-        assert!(test_env.config().paths.proxies_dir.exists());
+        assert!(test_env.config().paths.proxy_dir.join("bin").exists());
 
         assert!(matches!(
             update(
                 test_env.config(),
                 state,
-                &test_env.config().paths.proxies_dir
+                &test_env.config().paths.proxy_dir.join("bin")
             )
             .await,
             Err(BinaryProxyUpdateError::ProxyBinaryShouldNotBeDir(_))

--- a/crates/criticalup-core/src/config/paths.rs
+++ b/crates/criticalup-core/src/config/paths.rs
@@ -12,12 +12,10 @@ const DEFAULT_INSTALLATION_DIR_NAME: &str = "toolchains";
 pub struct Paths {
     pub(crate) state_file: PathBuf,
 
-    pub proxies_dir: PathBuf,
+    pub proxy_dir: PathBuf,
     pub installation_dir: PathBuf,
     pub cache_dir: PathBuf,
-
-    #[cfg(test)]
-    pub(crate) root: PathBuf,
+    pub root: PathBuf,
 }
 
 impl Paths {
@@ -45,10 +43,9 @@ impl Paths {
 
         Ok(Paths {
             state_file: root.join("state.json"),
-            proxies_dir: root.join("bin"),
+            proxy_dir: root.join("proxy"),
             installation_dir: root.join(DEFAULT_INSTALLATION_DIR_NAME),
             cache_dir,
-            #[cfg(test)]
             root,
         })
     }
@@ -92,7 +89,7 @@ mod tests {
         assert_eq!(
             Paths {
                 state_file: "/opt/criticalup/state.json".into(),
-                proxies_dir: "/opt/criticalup/bin".into(),
+                proxy_dir: "/opt/criticalup/proxy".into(),
                 installation_dir: "/opt/criticalup/toolchains".into(),
                 cache_dir: "/cache/criticalup".into(),
                 root: "/opt/criticalup".into()

--- a/crates/criticalup-core/src/errors.rs
+++ b/crates/criticalup-core/src/errors.rs
@@ -192,8 +192,10 @@ pub enum BinaryProxyUpdateError {
         #[source]
         inner: std::io::Error,
     },
-    #[error("Failed to create the parent directory {}.", .0.display())]
-    ParentDirectoryCreationFailed(PathBuf, #[source] std::io::Error),
+    #[error("Failed to create the directory {}.", .0.display())]
+    DirectoryCreationFailed(PathBuf, #[source] std::io::Error),
+    #[error("Failed to remove the directory {}.", .0.display())]
+    DirectoryRemovalFailed(PathBuf, #[source] std::io::Error),
     #[error(
         "The path of the proxy binary provided is a directory but needs to be a file or symlink."
     )]

--- a/docs/src/using-criticalup/running-tools.rst
+++ b/docs/src/using-criticalup/running-tools.rst
@@ -57,21 +57,52 @@ binaries for a given workspace. These can be added to your shell path on any OS.
 
 It's important to note that these binaries share the same binary names as any Rust toolchain that
 may already be installed. If you already have Rust installed (for example, via ``rustup``) you
-may wish either to remove it, use Ferrocene via ``criticalup run``, or remove the upstream Rust
-toolchain from your path and use ``rustup run`` to access it.
+should either to remove it, use Ferrocene via ``criticalup run``, or add Ferrocene as a ``rustup``
+toolchain.
+
+Optionally, Ferrocene can be used as a ``rustup`` toolchain, after following platform specific instructions below.
+
+Example usage:
+
+.. code-block:: 
+   
+   cargo +ferrocene build --release
+   cargo +ferrocene test
+
+It's also possible to have ``rustup`` use the Ferrocene toolchain by default:
+
+.. code-block::
+
+   rustup default ferrocene
 
 Linux
 -----
 
-Proxies are located at ``$XDG_DATA_HOME/criticalup/bin``, typically this is
-``~/.local/share/criticalup/bin/``.
+Proxies are located at ``$XDG_DATA_HOME/criticalup/proxy/bin``, typically this is
+``~/.local/share/criticalup/proxy/bin/``.
+
+Via ``rustup``
+""""""""""""""
+
+Configure the proxy:
+
+.. code-block::
+   
+   rustup toolchain link ferrocene ~/.local/share/criticalup/proxy/
+
+Then try running ``rustc +ferrocene --version`` and ensure it says *'Ferrocene by Ferrous Systems'*.
+
+You can now use Ferrocene as a regular ``rustup`` toolchain.
+
+Directly
+""""""""
 
 You can add the following line to your ``~/.bashrc`` or ``~/.zshrc`` to add the binary proxies to
 your ``PATH``:
 
 .. code-block::
 
-   export PATH="$PATH:$HOME/.local/share/criticalup/bin"
+   export PATH="$PATH:$HOME/.local/share/criticalup/proxy/bin"
 
 If you're using a different shell, such as
 `nushell <https://www.nushell.sh/book/configuration.html#path-configuration>`_, you may need to
@@ -80,13 +111,30 @@ consult the shell's documentation on how to add to the path.
 macOS
 -----
 
-Proxies are located at ``~/Library/Application Support/criticalup/bin/``. 
+Proxies are located at ``~/Library/Application Support/criticalup/proxy/bin/``. 
+
+Via ``rustup``
+""""""""""""""
+
+Configure the proxy:
+
+.. code-block::
+
+   rustup toolchain link ferrocene ~/Library/Application Support/criticalup/proxy/
+
+Then try running ``rustc +ferrocene --version`` and ensure it says *'Ferrocene by Ferrous Systems'*.
+
+You can now use Ferrocene as a regular ``rustup`` toolchain.
+
+
+Directly
+""""""""
 
 You can add the following line to your ``~/.zshrc`` to add the binary proxies to your ``PATH``:
 
 .. code-block::
 
-   export PATH="$PATH:$HOME/Library/Application Support/criticalup/bin"
+   export PATH="$PATH:$HOME/Library/Application Support/criticalup/proxy/bin"
 
 If you're using a different shell, such as
 `nushell <https://www.nushell.sh/book/configuration.html#path-configuration>`_, you may need to
@@ -95,7 +143,23 @@ consult the shell's documentation on how to add to the path.
 Windows
 -------
 
-Proxies are located at ``%appdata%\criticalup\bin\``:
+Proxies are located at ``%appdata%\criticalup\proxy\bin\``.
+
+Via ``rustup`` (Powershell)
+"""""""""""""""""""""""""""
+
+Configure the proxy:
+
+.. code-block::
+
+   rustup toolchain link ferrocene "$($env:USERPROFILE)\AppData\Roaming\criticalup\proxy\"
+
+Then try running ``rustc +ferrocene --version`` and ensure it says *'Ferrocene by Ferrous Systems'*.
+
+You can now use Ferrocene as a regular ``rustup`` toolchain.
+
+Directly
+""""""""
 
 On Windows 11, you can add the folder to your system path by hitting the Windows key and searching 
 'Edit environment variables for your account', then selecting the control panel. If you can't find
@@ -109,7 +173,7 @@ Once there, edit the ``PATH`` variable to include the following entry:
 
 .. code-block::
 
-   %USERPROFILE%\AppData\Roaming\criticalup\bin\
+   %USERPROFILE%\AppData\Roaming\criticalup\proxy\bin\
 
 You'll then need to sign out, and back in for changes to take effect.
 

--- a/docs/src/using-criticalup/running-tools.rst
+++ b/docs/src/using-criticalup/running-tools.rst
@@ -120,7 +120,7 @@ Configure the proxy:
 
 .. code-block::
 
-   rustup toolchain link ferrocene ~/Library/Application Support/criticalup/proxy/
+   rustup toolchain link ferrocene "~/Library/Application Support/criticalup/proxy/"
 
 Then try running ``rustc +ferrocene --version`` and ensure it says *'Ferrocene by Ferrous Systems'*.
 


### PR DESCRIPTION
A few things:

* Allow using `rustup toolchain link ferrocene CRITICALUP_HOME/proxy`
* Migrate proxy binaries from `CRITICALUP_HOME/bin` to `CRITICALUP_HOME/proxy/bin`
* Clean up old proxy location, advertise new `rustup toolchain link` support
* Update docs to highlight how to do `rustup toolchain link`


Test via:

1. `cargo install --path crates/criticalup-dev`
1. `criticalup-dev install --reinstall` (Observe migration log!)
1. `rustup link ferrocene CRITICALUP_HOME/proxy` (see docs)
1. `cargo +ferrocene build`
1. Try reinstalling, ensure no migration log
1. Hit it with a big stonking wrench however you please
1. Also, try upgrading criticalup in place, then using the old binaries

Manually tested on:

* [x] Linux (@amanjeev)
* [x] macOS (@Hoverbear)
  <img width="827" alt="image" src="https://github.com/user-attachments/assets/ff2a929a-dcef-4a60-b832-bb7e686526c0" />
* [x] Windows (@Hoverbear)
  ![image](https://github.com/user-attachments/assets/0d65c417-756c-449d-b42e-b808cfdadc48)
