### PR TITLE
Using the Ferrocene toolchain in a project by default

### DIFF
--- a/docs/src/using-criticalup/running-tools.rst
+++ b/docs/src/using-criticalup/running-tools.rst
@@ -103,6 +103,18 @@ It's also possible to have ``rustup`` use the Ferrocene toolchain by default:
 
    rustup default ferrocene
 
+You can configure your project to use the ``ferrocene`` toolchain by default
+by creating a ``rust-toolchain.toml``:
+
+.. code-block::
+
+   [toolchain]
+   channel = "ferrocene"
+
+Then, by default, the Ferrocene toolchain created above should be used. Other
+``rustup`` toolchains can still be used, for example, ``cargo +stable run``.
+
+
 On your shell path
 ------------------
 

--- a/docs/src/using-criticalup/toolchain-management.rst
+++ b/docs/src/using-criticalup/toolchain-management.rst
@@ -40,7 +40,7 @@ CriticalUp understands ``${rustc-host}`` to mean the target triple of the host o
    Options for ``criticalup.toml`` are detailed in :ref:`the reference <criticalup_toml>`.
 
 Creating a ``criticalup.toml``
------------------------------------
+------------------------------
 
 You can create a ``criticalup.toml`` using the ``init`` command.
 


### PR DESCRIPTION
Documents how to set `rust-toolchain.toml` to set your Ferrocene toolchain as the default.