### PR TITLE
chore: simplify workspace setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Check Clippy warnings
-        run: cargo clippy --workspace --tests --locked -- -Dwarnings
+        run: cargo clippy --tests --locked -- -Dwarnings
 
       - name: Prepare file to record snapshots used by insta
         run: echo "INSTA_SNAPSHOT_REFERENCES_FILE=$(mktemp)" >> "${GITHUB_ENV}"
@@ -88,12 +88,12 @@ jobs:
       - name: Run the test suite (Without AWS KMS)
         if: ${{ runner.os != 'Linux' && inputs.test == true }}
         run: |
-          cargo test --target ${{ inputs.target }} --workspace --locked
+          cargo test --target ${{ inputs.target }} --locked
 
       - name: Run the test suite (With AWS KMS)
         if: ${{ runner.os == 'Linux' && inputs.test == true }}
         run: |
-          cargo test --target ${{ inputs.target }} --workspace --locked --features aws-kms -- --test-threads=1
+          cargo test --target ${{ inputs.target }} --locked --features aws-kms -- --test-threads=1
 
       # Incompatible with Windows, insta snapshots output Windows paths
       # Incompatible with Mac, find does not have `-n`, diff does not have `--color`
@@ -110,7 +110,7 @@ jobs:
           cp target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup criticalup-${{ inputs.target }}/criticalup${{ (runner.os == 'Windows' && '.exe') || '' }}
           cp crates/criticalup/README.md criticalup-${{ inputs.target }}/README.md
           cp CHANGELOG.md criticalup-${{ inputs.target }}/CHANGELOG.md
-          
+
       - name: Make archive (tar.xz)
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,17 +2,9 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
 [workspace]
-members = [
-    "crates/criticaltrust",
-    "crates/criticalup-core",
-    "crates/criticalup-cli",
-    "crates/mock-download-server",
-    "crates/criticalup-dev",
-    "crates/criticalup",
-]
 resolver = "2"
+members = [ "crates/*"]
 exclude = ["docs/.linkchecker/src/tools/linkchecker"]
-default-members = ["crates/criticalup"]
 
 [workspace.dependencies]
 dirs = { version = "6.0.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo build -p criticalup --release
 To test CriticalUp from workspace root:
 
 ```bash
-cargo test --timings --workspace --locked
+cargo test --timings --locked
 ```
 
 To test a CriticalUp specific package from workspace root:
@@ -76,7 +76,7 @@ To cut a release:
       Update this test to match the correct version (`X.Y.Z`).
     - [CHANGELOG.md](./CHANGELOG.md): Make `[Unreleased]` the correct version (`[X.Y.Z]`). Add correct links metadata at
       the bottom.
-- Run `cargo test --workspace` and `cargo clippy --workspace --tests --locked -- -Dwarnings` to make sure there no
+- Run `cargo test` and `cargo clippy --tests --locked -- -Dwarnings` to make sure there no
   failures.
 - Commit and push this branch and open a PR against `main`, on GitHub.
 - Wait for approval(s) from reviewer(s).


### PR DESCRIPTION
Removes `default-members` key from the cargo workspace configuration. By doing so  
cargo commands run at the root of the workspace run on all the workspace members, which is the default behavior.

**pros**
Use less flags by keeping the standard behavior of running in all workspace members.
if `--workspace` is forgotten the default `cargo test` doesn't run anything, which is dangerous.

**cons**
breaking things with these changes, lets see the ci