### PR TITLE
Reduce unwraps in install

### DIFF
--- a/crates/criticalup-cli/src/cli/subcommand/install.rs
+++ b/crates/criticalup-cli/src/cli/subcommand/install.rs
@@ -165,7 +165,8 @@ async fn install_product_afresh(
             .await?;
         install_tx
             .send((package.to_owned(), package_data))
-            .await.map_err(|_| Error::SendError("Failed to send installation begin message".into()))?;
+            .await
+            .map_err(|_| Error::SendError("Failed to send installation begin message".into()))?;
     }
     // Tx must be dropped to indicate the end of the operation.
     drop(install_tx);

--- a/crates/criticalup-cli/src/cli/subcommand/install.rs
+++ b/crates/criticalup-cli/src/cli/subcommand/install.rs
@@ -16,6 +16,7 @@ use criticalup_core::download_server_client::DownloadServerClient;
 use criticalup_core::project_manifest::{ProjectManifest, ProjectManifestProduct};
 use criticalup_core::state::State;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tracing::{Instrument, Span};
 
 pub const DEFAULT_RELEASE_ARTIFACT_FORMAT: ReleaseArtifactFormat = ReleaseArtifactFormat::TarXz;
@@ -134,21 +135,23 @@ async fn install_product_afresh(
         .create_product_dir(&ctx.config.paths.installation_dir)
         .await?;
     // Finish channel must be opened in advance and be ready to rx; if not, the code remains sequential.
-    let (finish_tx, mut finish_rx) = mpsc::channel(1);
+    let (finish_tx, mut finish_rx) = mpsc::channel(product.packages().len());
     let (product_name_clone, release_clone): (String, String) =
         (product_name.to_owned(), release.to_owned());
 
     let (install_tx, mut install_rx) = mpsc::channel(1);
-    tokio::spawn(async move {
+    let handle: JoinHandle<Result<_, Error>> = tokio::spawn(async move {
         while let Some((package_name, package_data)) = install_rx.recv().await {
             tracing::info!(
                 "Installing component '{package_name}' for '{product_name_clone}' ({release_clone})",
             );
             let files = install_one_package(&abs_installation_dir_path, package_data).await;
-            finish_tx.send(files).await.unwrap();
+            finish_tx.send(files).await.map_err(|_| Error::SendError("Failed to send installation complete message".into()))?;
         }
         // Tx must be dropped to indicate the end of the operation.
         drop(finish_tx);
+
+        Ok(())
     }.instrument(Span::current()));
 
     for package in product.packages() {
@@ -159,14 +162,12 @@ async fn install_product_afresh(
                 package,
                 DEFAULT_RELEASE_ARTIFACT_FORMAT,
             )
-            .await
-            .unwrap();
+            .await?;
         install_tx
             .send((package.to_owned(), package_data))
-            .await
-            .unwrap();
+            .await.map_err(|_| Error::SendError("Failed to send installation begin message".into()))?;
     }
-    // Same as finish_tx, we send None to indicate the end of the operation.
+    // Tx must be dropped to indicate the end of the operation.
     drop(install_tx);
 
     while let Some(res) = finish_rx.recv().await {
@@ -176,6 +177,7 @@ async fn install_product_afresh(
             integrity_verifier.add(path.as_ref(), mode, buffer);
         }
     }
+    handle.await??; // Ensure we exit with any odd errors.
 
     let verified_packages = integrity_verifier
         .verify()
@@ -187,6 +189,7 @@ async fn install_product_afresh(
         manifest_path,
         &ctx.config,
     )?;
+
     Ok(())
 }
 

--- a/crates/criticalup-cli/src/cli/subcommand/install.rs
+++ b/crates/criticalup-cli/src/cli/subcommand/install.rs
@@ -146,7 +146,7 @@ async fn install_product_afresh(
                 "Installing component '{package_name}' for '{product_name_clone}' ({release_clone})",
             );
             let files = install_one_package(&abs_installation_dir_path, package_data).await;
-            finish_tx.send(files).await.map_err(|_| Error::SendError("Failed to send installation complete message".into()))?;
+            finish_tx.send(files).await.map_err(|_| Error::Send("Failed to send installation complete message".into()))?;
         }
         // Tx must be dropped to indicate the end of the operation.
         drop(finish_tx);
@@ -166,7 +166,7 @@ async fn install_product_afresh(
         install_tx
             .send((package.to_owned(), package_data))
             .await
-            .map_err(|_| Error::SendError("Failed to send installation begin message".into()))?;
+            .map_err(|_| Error::Send("Failed to send installation begin message".into()))?;
     }
     // Tx must be dropped to indicate the end of the operation.
     drop(install_tx);

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -181,7 +181,7 @@ pub(crate) enum Error {
     CommandExitNonzero(String, Output),
 
     #[error("Send error")]
-    SendError(String), // We don't include the source error as it contains the generic value
+    Send(String), // We don't include the source error as it contains the generic value
 
     #[cfg(windows)]
     #[error("Could not set Ctrl-C handler.")]

--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -180,6 +180,9 @@ pub(crate) enum Error {
     #[error("Non-successful exit for command `{}`, stderr: \n{}", .0, String::from_utf8_lossy(&.1.stderr))]
     CommandExitNonzero(String, Output),
 
+    #[error("Send error")]
+    SendError(String), // We don't include the source error as it contains the generic value
+
     #[cfg(windows)]
     #[error("Could not set Ctrl-C handler.")]
     CtrlHandler,


### PR DESCRIPTION
#121 made it possible to download and install packages at the same time, however it introduced some situations where it was possible installation would hang. Also, it introduced some unwraps that need not exist.

This addresses those.