### PR TITLE
Don't toolchain link on release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           token: ${{ secrets.CRITICALUP_TOKEN }}
           uninstall-rust: true  
+          toolchain-link: false
 
       - name: Install WiX
         run: |


### PR DESCRIPTION
We noticed in #130 was broken and reverted it in #131, we'll re-release.