### PR TITLE
Reapply "Release 1.5.0-prerelease.1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [1.5.0-prerelease.1] - 2025-07-14
 
 ### Changed
 
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - The reworked `criticalup run` behavior was not correctly checking that the toolchain specified
-  in `criticalup.toml` was installed. This lead to some situations where users could accidentally 
+  in `criticalup.toml` was installed. This lead to some situations where users could accidentally
   run a non-Ferrocene tool when they meant to run Ferrocene tools. This behavior has been altered
   and CriticalUp will now present users with an error suggesting they install the toolchain.
 
@@ -126,7 +126,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.5.0-prerelease.1...HEAD
+
+[1.5.0-prerelease.1]: https://github.com/ferrocene/criticalup/compare/v1.4.0...1.5.0-prerelease.1
 
 [1.4.0]:  https://github.com/ferrocene/criticalup/compare/v1.3.0...1.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-cli"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 dependencies = [
  "clap",
  "criticaltrust",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-dev"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-cli"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 edition = "2021"
 repository = "https://github.com/ferrocene/criticalup"
 homepage = "https://github.com/ferrocene/criticalup"

--- a/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
@@ -8,5 +8,5 @@ empty stdout
 
 stderr
 ------
-criticalup-test 1.4.1-prerelease.1
+criticalup-test 1.5.0-prerelease.1
 ------

--- a/crates/criticalup-dev/Cargo.toml
+++ b/crates/criticalup-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-dev"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 edition = "2021"
 publish = false
 

--- a/crates/criticalup/Cargo.toml
+++ b/crates/criticalup/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 edition = "2021"
 authors = ["The CriticalUp Developers"]
 description = "Ferrocene toolchain manager"


### PR DESCRIPTION
This reverts commit fcb7a404971d432b64fb95d74baca766c2f25197.

:info: We tried to cut a [v1.5.0-prerelease.1](https://github.com/ferrocene/criticalup/pull/130) yesterday evening  but it [failed](https://github.com/ferrocene/criticalup/actions/runs/16276253130/job/45955749972#step:3:40). We've [reverted](https://github.com/ferrocene/criticalup/pull/131) and have a [fix](https://github.com/ferrocene/criticalup/pull/132).
