### PR TITLE
Release v1.5.0-prerelease.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [1.5.0-prerelease.1] - 2025-07-17
 
 ### Changed
 
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - The reworked `criticalup run` behavior was not correctly checking that the toolchain specified
-  in `criticalup.toml` was installed. This lead to some situations where users could accidentally 
+  in `criticalup.toml` was installed. This lead to some situations where users could accidentally
   run a non-Ferrocene tool when they meant to run Ferrocene tools. This behavior has been altered
   and CriticalUp will now present users with an error suggesting they install the toolchain.
 
@@ -126,7 +126,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.5.0-prerelease.1...HEAD
+
+[1.5.0-prerelease.1]:  https://github.com/ferrocene/criticalup/compare/v1.4.0...v1.5.0-prerelease.1
 
 [1.4.0]:  https://github.com/ferrocene/criticalup/compare/v1.3.0...1.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-cli"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 dependencies = [
  "clap",
  "criticaltrust",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-dev"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-cli"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 edition = "2021"
 repository = "https://github.com/ferrocene/criticalup"
 homepage = "https://github.com/ferrocene/criticalup"

--- a/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
@@ -8,5 +8,5 @@ empty stdout
 
 stderr
 ------
-criticalup-test 1.4.1-prerelease.1
+criticalup-test 1.5.0-prerelease.1
 ------

--- a/crates/criticalup-dev/Cargo.toml
+++ b/crates/criticalup-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-dev"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 edition = "2021"
 publish = false
 

--- a/crates/criticalup/Cargo.toml
+++ b/crates/criticalup/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup"
-version = "1.4.1-prerelease.1"
+version = "1.5.0-prerelease.1"
 edition = "2021"
 authors = ["The CriticalUp Developers"]
 description = "Ferrocene toolchain manager"


### PR DESCRIPTION
### Changed

- Added improved caching support using HTTP caching. Before installing packages,
  they are validated to be correct and available against the server via HTTP caching
  using `If-None-Match` and `ETag` headers.
- Added a 90 second connect/idle timeouts in the download client, which should reduce the risk of long hangs
  in exotic networking situations.
- Altered the location of the binary proxies to enable clean integration with `rustup toolchain link`.
  Previously, binary proxies were in the `bin/` folder of the CriticalUp home, now they are in `proxy/bin/`.

### Added

- Added a `--log-format $FORMAT` flag, with the options of `default`, `pretty`, `tree`, and `json`.
  The `default` option preserves existing behavior, while `pretty` shows the previous `--verbose` format,
  `json` outputs as JSON, and `tree` displays logging span structure.
- Added support registering the CriticalUp binary proxies as a `rustup` toolchain. You can now run
  `criticalup link create` then use, for example, `cargo +ferrocene build`.

### Removed

- Removed support for package revocation via signatures. Instead, cached packages are
  validated to be still available online before use, except when `--offline` is passed.
- Removed an experimental feature that attempted to integrate with Docker secrets. After more testing,
  our team was unsatisfied with its behavior and opted not to mature it.
