### PR TITLE
Make doc deploy happen later in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
 
   deploy-docs:
     secrets: inherit
+    needs:
+      - build
+      - package
     uses: ./.github/workflows/deploy-docs.yml
 
   release:


### PR DESCRIPTION
We should make deploying the docs happen later in the release.