### PR TITLE
Release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.1] - 2025-07-28
+
+### Fixed
+
+- Resolved an issue on aarch64-apple-darwin where liblzma was required to be installed on the user's system. The dependency is now statically linked.
+
 ## [1.5.0] - 2025-07-17
 
 ### Changed
@@ -126,7 +132,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/ferrocene/criticalup/compare/v1.5.1...HEAD
+
+[1.5.1]:  https://github.com/ferrocene/criticalup/compare/v1.5.0...v1.5.1
 
 [1.5.0]:  https://github.com/ferrocene/criticalup/compare/v1.4.0...v1.5.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-cli"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "clap",
  "criticaltrust",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "criticalup-dev"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "criticaltrust",
  "criticalup-cli",

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-cli"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 repository = "https://github.com/ferrocene/criticalup"
 homepage = "https://github.com/ferrocene/criticalup"

--- a/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__root__version_flags.snap
@@ -8,5 +8,5 @@ empty stdout
 
 stderr
 ------
-criticalup-test 1.5.0
+criticalup-test 1.5.1
 ------

--- a/crates/criticalup-dev/Cargo.toml
+++ b/crates/criticalup-dev/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup-dev"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 

--- a/crates/criticalup/Cargo.toml
+++ b/crates/criticalup/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "criticalup"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 authors = ["The CriticalUp Developers"]
 description = "Ferrocene toolchain manager"


### PR DESCRIPTION
Resolved an issue on aarch64-apple-darwin where liblzma was required to be installed on the user's system. The dependency is now statically linked.
