### PR TITLE
Added tests for integrating with a generic artifacts server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "futures",
  "hyper 1.6.0",
  "insta",
+ "mock-artifact-server",
  "mock-download-server",
  "opener",
  "regex",
@@ -2070,6 +2071,25 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mock-artifact-server"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-extra",
+ "criticaltrust",
+ "http-body-util",
+ "serde_json",
+ "sha2",
+ "tar",
+ "tempfile",
+ "time",
+ "tokio",
+ "walkdir",
+ "xz2",
 ]
 
 [[package]]

--- a/crates/criticalup-cli/Cargo.toml
+++ b/crates/criticalup-cli/Cargo.toml
@@ -42,6 +42,7 @@ hyper.workspace = true
 dirs.workspace = true
 insta = { version = "1.42.2", features = ["filters"] }
 mock-download-server = { path = "../mock-download-server" }
+mock-artifact-server = { path = "../mock-artifact-server" }
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 tempfile.workspace = true

--- a/crates/criticalup-cli/tests/cli/artifact_server_install.rs
+++ b/crates/criticalup-cli/tests/cli/artifact_server_install.rs
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::utils::TestEnvironment;
+use hyper::StatusCode;
+use mock_artifact_server::MockArtifactServer;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn run_install_successfully() {
+    let mut test_env = TestEnvironment::prepare().await;
+
+    // Create a release with one package.
+    let package_ref = "rustc";
+    let product_ref = "ferrocene";
+    let release_ref = "25.05.0";
+
+    let work_dir_binding = tempdir().unwrap();
+    let work_dir = work_dir_binding.path();
+    let output_dir = work_dir.join("output");
+    tokio::fs::create_dir_all(&output_dir).await.unwrap();
+
+    let input_dir = work_dir.join("input");
+    tokio::fs::create_dir_all(input_dir.join("bin"))
+        .await
+        .unwrap();
+    tokio::fs::write(input_dir.join("bin").join("rustc"), "hello")
+        .await
+        .unwrap();
+    assert!(input_dir.join("bin/rustc").exists());
+
+    let server: &mut MockArtifactServer = test_env.artifact_server();
+
+    server
+        .create_package(package_ref, product_ref, &input_dir, &output_dir)
+        .await
+        .unwrap();
+    server
+        .create_release(product_ref, release_ref, vec![package_ref], &output_dir)
+        .await
+        .unwrap();
+
+    let manifest = toml::toml! {
+        manifest-version = 1
+
+        [products.ferrocene]
+        release = release_ref
+        packages = [
+            package_ref,
+        ]
+    }
+    .to_string();
+
+    let manifest_path = work_dir.join("criticalup.toml");
+    tokio::fs::write(&manifest_path, manifest).await.unwrap();
+
+    run_install_cmd(&test_env, manifest_path.to_str().unwrap(), false).await;
+
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        1,
+        "/v1/keys",
+        StatusCode::PERMANENT_REDIRECT,
+    )
+    .await;
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        1,
+        "/keys.json",
+        StatusCode::OK,
+    )
+    .await;
+
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        1,
+        "/v1/releases/ferrocene/25.05.0",
+        StatusCode::PERMANENT_REDIRECT,
+    )
+    .await;
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        1,
+        "/artifacts/products/ferrocene/releases/25.05.0/manifest.json",
+        StatusCode::OK,
+    )
+    .await;
+
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        1,
+        "/v1/releases/ferrocene/25.05.0/download/rustc/tar.xz",
+        StatusCode::PERMANENT_REDIRECT,
+    )
+    .await;
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        1,
+        "/artifacts/products/ferrocene/releases/25.05.0/rustc.tar.xz",
+        StatusCode::OK,
+    )
+    .await;
+
+    run_install_cmd(&test_env, manifest_path.to_str().unwrap(), true).await;
+
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        2,
+        "/v1/keys",
+        StatusCode::PERMANENT_REDIRECT,
+    )
+    .await;
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        2,
+        "/keys.json",
+        StatusCode::OK,
+    )
+    .await;
+
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        2,
+        "/v1/releases/ferrocene/25.05.0",
+        StatusCode::PERMANENT_REDIRECT,
+    )
+    .await;
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        2,
+        "/artifacts/products/ferrocene/releases/25.05.0/manifest.json",
+        StatusCode::OK,
+    )
+    .await;
+
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        2,
+        "/v1/releases/ferrocene/25.05.0/download/rustc/tar.xz",
+        StatusCode::PERMANENT_REDIRECT,
+    )
+    .await;
+    assert_url_called_n_times_and_returns_status_code(
+        &mut test_env,
+        2,
+        "/artifacts/products/ferrocene/releases/25.05.0/rustc.tar.xz",
+        StatusCode::OK,
+    )
+    .await;
+}
+
+async fn assert_url_called_n_times_and_returns_status_code(
+    test_env: &mut TestEnvironment,
+    n: u8,
+    url: &str,
+    status_code: StatusCode,
+) {
+    assert_eq!(
+        {
+            let history = test_env.artifact_server().history().await;
+            let downloads = history
+                .iter()
+                .filter(|(req, _)| req.uri() == url)
+                .collect::<Vec<_>>();
+
+            let uri_history = history.iter().map(|(req, _)| req.uri()).collect::<Vec<_>>();
+            assert_eq!(
+                downloads.len(),
+                n as usize,
+                "filtered history {downloads:?} total history {uri_history:?}"
+            );
+            let (_, res) = downloads.last().unwrap();
+            res.status()
+        },
+        status_code,
+    );
+}
+
+async fn run_install_cmd(test_env: &TestEnvironment, manifest_path: &str, reinstall: bool) {
+    let mut command = test_env.cmd_with_artifact_server();
+    command.args(["install", "--project", manifest_path]);
+
+    if reinstall {
+        command.arg("--reinstall");
+    }
+
+    let output = command.output().await.unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/criticalup-cli/tests/cli/main.rs
+++ b/crates/criticalup-cli/tests/cli/main.rs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: The Ferrocene Developers
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+mod artifact_server_install;
 mod auth;
 mod auth_remove;
 mod auth_set;

--- a/crates/criticalup-cli/tests/cli/utils.rs
+++ b/crates/criticalup-cli/tests/cli/utils.rs
@@ -4,6 +4,7 @@
 use criticaltrust::keys::{EphemeralKeyPair, KeyAlgorithm, KeyPair, KeyRole, PublicKey};
 use criticaltrust::manifests::{Release, ReleaseManifest};
 use criticaltrust::signatures::SignedPayload;
+use mock_artifact_server::MockArtifactServer;
 use mock_download_server::{AuthenticationToken, Builder, MockServer};
 use std::borrow::Cow;
 use std::io::{Seek, Write};
@@ -61,6 +62,7 @@ pub(crate) struct TestEnvironment {
     root: TempDir,
     trust_root: PublicKey,
     server: MockServer,
+    artifact_server: MockArtifactServer,
     customer_portal_url: String,
 }
 
@@ -73,12 +75,15 @@ impl TestEnvironment {
         )
         .unwrap();
 
+        let cloned_root_keypair = root_keypair.clone();
+
         let root = TempDir::new_in(std::env::current_dir().unwrap()).unwrap();
 
         TestEnvironment {
             root,
             trust_root: root_keypair.public().clone(),
             server: setup_mock_server(root_keypair).await,
+            artifact_server: setup_mock_artifact_server(cloned_root_keypair).await,
             customer_portal_url: "https://customers-test.ferrocene.dev".into(),
         }
     }
@@ -91,6 +96,25 @@ impl TestEnvironment {
         let mut command = Command::new(env!("CARGO_BIN_EXE_criticalup-test"));
         command.env("CRITICALUP_ROOT", self.root.path());
         command.env("CRITICALUP_TEST_DOWNLOAD_SERVER_URL", self.server.url());
+        command.env(
+            "CRITICALUP_TEST_CUSTOMER_PORTAL_URL",
+            &self.customer_portal_url,
+        );
+        command.env(
+            "CRITICALUP_TEST_TRUST_ROOT",
+            serde_json::to_string(&self.trust_root).unwrap(),
+        );
+        command.env("CRITICALUP_TESTING_IN_PROGRESS", "1");
+        command
+    }
+
+    pub(crate) fn cmd_with_artifact_server(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_criticalup-test"));
+        command.env("CRITICALUP_ROOT", self.root.path());
+        command.env(
+            "CRITICALUP_TEST_DOWNLOAD_SERVER_URL",
+            self.artifact_server.url(),
+        );
         command.env(
             "CRITICALUP_TEST_CUSTOMER_PORTAL_URL",
             &self.customer_portal_url,
@@ -124,6 +148,11 @@ impl TestEnvironment {
     // Beware of the consumption.
     pub(crate) fn server(&mut self) -> &mut MockServer {
         &mut self.server
+    }
+
+    // Beware of the consumption.
+    pub(crate) fn artifact_server(&mut self) -> &mut MockArtifactServer {
+        &mut self.artifact_server
     }
 }
 
@@ -162,6 +191,50 @@ async fn setup_mock_server(root_keypair: EphemeralKeyPair) -> MockServer {
     server_builder =
         add_non_root_key_to_server(server_builder, "packages", KeyRole::Packages, &root_keypair)
             .await;
+
+    for (product, release, mut manifest) in mock_release_manifests() {
+        manifest.signed.add_signature(&root_keypair).await.unwrap();
+        server_builder = server_builder.add_release_manifest(
+            product.to_string(),
+            release.to_string(),
+            manifest.clone(),
+        );
+    }
+    server_builder.start().await
+}
+
+async fn setup_mock_artifact_server(root_keypair: EphemeralKeyPair) -> MockArtifactServer {
+    let mut server_builder = mock_artifact_server::Builder::new();
+
+    // Root keypair.
+    // This is the only keypair that is added without adding a public signed payload because
+    // Root is self-trusting and has no parent to sign its public key.
+    server_builder = server_builder.add_keypair(root_keypair.to_owned(), "root");
+
+    // Releases keypair.
+    server_builder = add_non_root_key_to_artifact_server(
+        server_builder,
+        "releases",
+        KeyRole::Releases,
+        &root_keypair,
+    )
+    .await;
+    // Revocation keypair.
+    server_builder = add_non_root_key_to_artifact_server(
+        server_builder,
+        "revocation",
+        KeyRole::Revocation,
+        &root_keypair,
+    )
+    .await;
+    // Packages keypair.
+    server_builder = add_non_root_key_to_artifact_server(
+        server_builder,
+        "packages",
+        KeyRole::Packages,
+        &root_keypair,
+    )
+    .await;
 
     for (product, release, mut manifest) in mock_release_manifests() {
         manifest.signed.add_signature(&root_keypair).await.unwrap();
@@ -352,6 +425,22 @@ async fn add_non_root_key_to_server(
     role: KeyRole,
     trusted_by: &EphemeralKeyPair,
 ) -> Builder {
+    let (keypair, signed_payload) = generate_trusted_key(role, trusted_by).await;
+    if name == "revocation" {
+        server_builder = server_builder.add_revocation_info(&keypair).await;
+    }
+    server_builder = server_builder.add_key(signed_payload);
+    server_builder = server_builder.add_keypair(keypair, name);
+
+    server_builder
+}
+
+async fn add_non_root_key_to_artifact_server(
+    mut server_builder: mock_artifact_server::Builder,
+    name: &str,
+    role: KeyRole,
+    trusted_by: &EphemeralKeyPair,
+) -> mock_artifact_server::Builder {
     let (keypair, signed_payload) = generate_trusted_key(role, trusted_by).await;
     if name == "revocation" {
         server_builder = server_builder.add_revocation_info(&keypair).await;

--- a/crates/mock-artifact-server/Cargo.toml
+++ b/crates/mock-artifact-server/Cargo.toml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The Ferrocene Developers
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+[package]
+name = "mock-artifact-server"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.97"
+criticaltrust = { path = "../criticaltrust", features = ["hash-revocation"] }
+tempfile.workspace = true
+tokio.workspace = true
+walkdir.workspace = true
+sha2.workspace = true
+xz2 = { workspace = true, features = ["static"] }
+time.workspace = true
+tar.workspace = true
+serde_json.workspace = true
+axum.workspace = true
+axum-extra.workspace = true
+http-body-util.workspace = true

--- a/crates/mock-artifact-server/src/handlers.rs
+++ b/crates/mock-artifact-server/src/handlers.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::sync::Arc;
+
+use crate::Data;
+use axum::extract::{Path, State};
+use axum::response::IntoResponse;
+use axum::Json;
+use criticaltrust::manifests::ManifestVersion;
+use tokio::sync::Mutex;
+
+pub(crate) async fn handle_v1_package(
+    State(data): State<Arc<Mutex<Data>>>,
+    Path((product, release, package)): Path<(String, String, String)>,
+) -> impl IntoResponse {
+    let data = data.lock().await;
+
+    // we cannot pass 2 parameters in the url /{package}.{format}
+    let package = package.replace(".tar.xz", "");
+
+    let bytes = data
+        .release_packages
+        .get(&(
+            product.to_string(),
+            release.to_string(),
+            package.to_string(),
+        ))
+        .unwrap()
+        .clone();
+    bytes.into_response()
+}
+
+pub(crate) async fn handle_v1_keys(State(data): State<Arc<Mutex<Data>>>) -> impl IntoResponse {
+    let data = data.lock().await;
+    Json(criticaltrust::manifests::KeysManifest {
+        version: ManifestVersion,
+        keys: data.keys.clone(),
+        revoked_signatures: data.revoked_signatures.clone(),
+    })
+}
+
+pub(crate) async fn handle_v1_release(
+    State(data): State<Arc<Mutex<Data>>>,
+    Path((product, release)): Path<(String, String)>,
+) -> impl IntoResponse {
+    let data = data.lock().await;
+    let rm = data
+        .release_manifests
+        .get(&(product.to_string(), release.to_string()))
+        .expect("Did not get a release manifest")
+        .to_owned();
+    Json(rm)
+}

--- a/crates/mock-artifact-server/src/lib.rs
+++ b/crates/mock-artifact-server/src/lib.rs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod handlers;
+mod server;
+
+pub use crate::server::MockArtifactServer;
+use axum::body::Body;
+use axum::extract::Path;
+use axum::http::{Request, Response};
+use axum::response::Redirect;
+use axum::routing::get;
+use axum::Router;
+use criticaltrust::keys::{EphemeralKeyPair, PublicKey};
+use criticaltrust::manifests::ReleaseManifest;
+use criticaltrust::revocation_info::RevocationInfo;
+use criticaltrust::signatures::SignedPayload;
+use std::collections::HashMap;
+use std::sync::Arc;
+use time::{Duration, OffsetDateTime};
+use tokio::sync::Mutex;
+
+// Make sure there is enough number of days for expiration so tests don't need constant updates.
+const EXPIRATION_EXTENSION_IN_DAYS: Duration = Duration::days(180);
+
+pub struct Data {
+    pub keypairs: HashMap<String, EphemeralKeyPair>,
+    pub keys: Vec<SignedPayload<PublicKey>>,
+    pub release_manifests: HashMap<(String, String), ReleaseManifest>,
+    pub revoked_signatures: SignedPayload<RevocationInfo>,
+    pub release_packages: HashMap<(String, String, String), Vec<u8>>,
+    pub history: Vec<(Request<Body>, Response<Body>)>,
+}
+
+pub struct Builder {
+    data: Data,
+}
+
+impl Builder {
+    pub fn new() -> Builder {
+        Builder {
+            data: Data {
+                keypairs: HashMap::new(),
+                keys: Vec::new(),
+                revoked_signatures: SignedPayload::new(&RevocationInfo::new(
+                    Vec::new(),
+                    OffsetDateTime::now_utc() + EXPIRATION_EXTENSION_IN_DAYS,
+                ))
+                .unwrap(),
+                release_manifests: HashMap::new(),
+                release_packages: HashMap::new(),
+                history: Vec::new(),
+            },
+        }
+    }
+
+    pub fn add_keypair(mut self, keypair: EphemeralKeyPair, name: &str) -> Self {
+        self.data.keypairs.insert(name.to_string(), keypair);
+        self
+    }
+
+    pub async fn add_revocation_info(mut self, revocation_key: &EphemeralKeyPair) -> Self {
+        self.data
+            .revoked_signatures
+            .add_signature(revocation_key)
+            .await
+            .unwrap();
+        self
+    }
+
+    pub fn add_key(mut self, key: SignedPayload<PublicKey>) -> Self {
+        self.data.keys.push(key);
+        self
+    }
+
+    pub fn add_release_manifest(
+        mut self,
+        product: String,
+        release: String,
+        manifest: ReleaseManifest,
+    ) -> Self {
+        self.data
+            .release_manifests
+            .insert((product, release), manifest);
+        self
+    }
+
+    pub async fn start(self) -> MockArtifactServer {
+        MockArtifactServer::spawn(self.data).await
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn v1_routes() -> Router<Arc<Mutex<Data>>> {
+    Router::new()
+        .route("/keys", get(|| async { Redirect::permanent("/keys.json") }))
+        .route(
+            "/releases/{product}/{release}",
+            get(
+                |Path((product, release)): Path<(String, String)>| async move {
+                    let uri =
+                        format!("/artifacts/products/{product}/releases/{release}/manifest.json");
+                    Redirect::permanent(uri.as_str())
+                },
+            ),
+        )
+        .route(
+            "/releases/{product}/{release}/download/{package}/{format}",
+            get(
+                |Path((product, release, package, format)): Path<(
+                    String,
+                    String,
+                    String,
+                    String,
+                )>| async move {
+                    let uri = format!(
+                        "/artifacts/products/{product}/releases/{release}/{package}.{format}"
+                    );
+                    Redirect::permanent(uri.as_str())
+                },
+            ),
+        )
+}

--- a/crates/mock-artifact-server/src/server.rs
+++ b/crates/mock-artifact-server/src/server.rs
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: The Ferrocene Developers
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::handlers::{handle_v1_keys, handle_v1_package, handle_v1_release};
+use crate::{v1_routes, Data};
+use anyhow::Result;
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{Response, StatusCode};
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{middleware, Router};
+use criticaltrust::manifests::{
+    ManifestVersion, Package, PackageFile, PackageManifest, Release, ReleaseArtifact,
+    ReleaseArtifactFormat, ReleaseManifest, ReleasePackage,
+};
+use criticaltrust::signatures::SignedPayload;
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+#[cfg(unix)]
+use std::os::unix::prelude::MetadataExt;
+#[cfg(windows)]
+use std::os::windows::prelude::MetadataExt;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
+use tokio::task::JoinHandle;
+use walkdir::WalkDir;
+use xz2::write::XzEncoder;
+
+pub struct MockArtifactServer {
+    data: Arc<Mutex<Data>>,
+    address: SocketAddr,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MockArtifactServer {
+    pub(crate) async fn spawn(data: Data) -> Self {
+        let data = Arc::new(Mutex::new(data));
+        let data_clone = data.clone();
+
+        // Binding on port 0 results in the operative system picking a random available port,
+        // without the need of generating a random port ourselves and validating the port is not
+        // being used by another process.
+        //
+        // The real port can be then retrieved by checking the address of the bound server.
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);
+        let listener = TcpListener::bind(&address).await.unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let mut this = Self {
+            data: data_clone,
+            address,
+            handle: None,
+        };
+        let router = Router::new()
+            .route("/", get(StatusCode::NOT_IMPLEMENTED))
+            .route("/health", get(StatusCode::OK))
+            .route("/keys.json", get(handle_v1_keys))
+            .route(
+                "/artifacts/products/{product}/releases/{release}/manifest.json",
+                get(handle_v1_release),
+            )
+            .route(
+                "/artifacts/products/{product}/releases/{release}/{package}",
+                get(handle_v1_package),
+            )
+            .nest("/v1", v1_routes())
+            .layer(middleware::from_fn_with_state(
+                Arc::clone(&data),
+                update_history,
+            ))
+            .fallback(StatusCode::NOT_FOUND)
+            .with_state(Arc::clone(&data));
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .await
+                .expect("failed to start server");
+        });
+
+        this.handle = Some(handle);
+
+        this
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}", self.address)
+    }
+
+    pub async fn served_requests_count(&self) -> usize {
+        self.data.lock().await.history.len()
+    }
+
+    pub async fn history(&self) -> MappedMutexGuard<'_, [(Request<Body>, Response<Body>)]> {
+        let guard = self.data.lock().await;
+        MutexGuard::map(guard, |v| v.history.as_mut_slice())
+    }
+
+    pub async fn edit_data(&self, f: impl FnOnce(MutexGuard<'_, Data>)) {
+        f(self.data.lock().await);
+    }
+
+    /// Creates a package, signs it and then tarballs it.
+    ///
+    /// This method is to be called within the test as many times as the number of packages
+    /// to be generated.
+    ///
+    /// `package_name`: Name of the package. Keep it unique please.
+    /// `product_name`: Name of the product, generally "ferrocene".
+    /// `input_dir`: Path to the directory where package data is kept.
+    /// `output_dir`: Path to the directory where output will be stored
+    pub async fn create_package(
+        &mut self,
+        package_name: &str,
+        product_name: &str,
+        input_dir: &Path,
+        output_dir: &Path,
+    ) -> Result<(), ()> {
+        let mut package = Package {
+            product: product_name.to_string(),
+            package: package_name.to_string(),
+            commit: "123abc".to_string(),
+            files: vec![],
+            managed_prefixes: vec![],
+        };
+
+        collect_files(&mut package, input_dir);
+        package.files.sort_by_cached_key(|file| file.path.clone());
+
+        let mut signed = SignedPayload::new(&package).unwrap();
+        let keypair = {
+            let keypair_lock = self.data.lock().await;
+            keypair_lock.keypairs.get("packages").unwrap().clone()
+        };
+        signed.add_signature(&keypair).await.unwrap();
+
+        let package_manifest_with_dir_structure = input_dir
+            .join("share")
+            .join("criticaltrust")
+            .join(product_name);
+        tokio::fs::create_dir_all(&package_manifest_with_dir_structure)
+            .await
+            .unwrap();
+        tokio::fs::write(
+            package_manifest_with_dir_structure.join(format!("{package_name}.json")),
+            serde_json::to_vec_pretty(&PackageManifest {
+                version: ManifestVersion::<1>,
+                signed,
+            })
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let archive_name = format!("{package_name}.tar.xz");
+        let output_compressed_file = File::create(output_dir.join(&archive_name)).unwrap();
+        let encoder = XzEncoder::new(output_compressed_file, 9);
+        let mut tar = tar::Builder::new(encoder);
+        tar.append_dir_all("", input_dir).unwrap();
+        tar.into_inner().unwrap().finish().unwrap();
+
+        Ok(())
+    }
+
+    /// Create a signed release.
+    ///
+    /// ** Use `Self::create_package()` before calling this method. **
+    ///
+    /// `product_name`: Name of the product, generally "ferrocene".
+    /// `release_name`: Release version, usually a string like "25.02.0".
+    /// `packages`: Vec of package names. It is important that these packages exist inside the
+    ///             output directory.
+    ///             Use `Self::create_package()` before calling this method.
+    /// `output_dir`: Path to the directory where output will be stored
+    ///                 (and output of `Self::create_package()` was previously stored.
+    pub async fn create_release(
+        &mut self,
+        product_name: &str,
+        release_name: &str,
+        packages: Vec<&str>,
+        output_dir: &Path,
+    ) -> Result<(), ()> {
+        let release_manifest = output_dir.join("criticalup-release-manifest.json");
+        let mut packages_update: Vec<ReleasePackage> = vec![];
+
+        // Create a `ReleasePackage` for each package in the vec. This is needed because we
+        // expect only package names.
+        for item in packages {
+            let artifact_file = std::fs::read(output_dir.join(format!("{item}.tar.xz"))).unwrap();
+            let artifact_file_metadata =
+                std::fs::metadata(output_dir.join(format!("{item}.tar.xz"))).unwrap();
+
+            let mut hasher = Sha256::new();
+            hasher.update(&artifact_file);
+            let hash = hasher.finalize().to_vec();
+
+            let artifact = ReleaseArtifact {
+                format: ReleaseArtifactFormat::TarXz,
+                #[cfg(not(windows))]
+                size: artifact_file_metadata.size() as usize,
+                #[cfg(windows)]
+                size: artifact_file_metadata.file_size() as usize,
+                sha256: hash,
+            };
+            packages_update.push(ReleasePackage {
+                package: item.to_string(),
+                artifacts: vec![artifact],
+                dependencies: vec![],
+            });
+
+            {
+                let mut data_grabbed = self.data.lock().await;
+                data_grabbed.release_packages.insert(
+                    (
+                        product_name.to_string(),
+                        release_name.to_string(),
+                        item.to_string(),
+                    ),
+                    artifact_file,
+                );
+            }
+        }
+
+        let mut signed = SignedPayload::new(&Release {
+            product: product_name.to_string(),
+            release: release_name.to_string(),
+            commit: "123abc".to_string(),
+            packages: packages_update,
+        })
+        .unwrap();
+        let keypair = {
+            let keypair_lock = self.data.lock().await;
+            keypair_lock.keypairs.get("releases").unwrap().clone()
+        };
+        signed.add_signature(&keypair).await.unwrap();
+
+        let release_manifest_content = &ReleaseManifest {
+            version: ManifestVersion,
+            signed,
+        };
+
+        tokio::fs::write(
+            &release_manifest,
+            serde_json::to_vec_pretty(release_manifest_content).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        {
+            let mut data_grabbed = self.data.lock().await;
+            data_grabbed.release_manifests.insert(
+                (product_name.to_string(), release_name.to_string()),
+                release_manifest_content.clone(),
+            );
+        }
+
+        Ok(())
+    }
+}
+
+fn collect_files(package: &mut Package, dir: &Path) {
+    for entry in WalkDir::new(dir) {
+        let entry = entry.unwrap();
+        let relative_path = entry.path().strip_prefix(dir).unwrap();
+        if entry.file_type().is_file() {
+            package.files.push(PackageFile {
+                path: relative_path.into(),
+                #[cfg(not(windows))]
+                posix_mode: entry.metadata().unwrap().mode(),
+                #[cfg(windows)]
+                posix_mode: 0,
+                sha256: hash_file(entry.path()),
+                needs_proxy: false,
+            })
+        } else if entry.file_type().is_file() {
+            collect_files(package, entry.path());
+        }
+    }
+}
+
+fn hash_file(path: &Path) -> Vec<u8> {
+    let mut sha256 = Sha256::new();
+    let mut contents = File::open(path).unwrap();
+    std::io::copy(&mut contents, &mut sha256).unwrap();
+    sha256.finalize().to_vec()
+}
+
+async fn update_history(
+    State(data): State<Arc<Mutex<Data>>>,
+    req: Request,
+    next: Next,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // Body does not implment Clone, that would be inefficient.
+    // But, we're in a test, and having a history is actually very useful.
+
+    let (req_parts, req_body) = req.into_parts();
+    let body_bytes = axum::body::to_bytes(req_body, usize::MAX).await.unwrap();
+    eprintln!("-> {} {}", req_parts.method, req_parts.uri);
+    let req_for_history = Request::from_parts(req_parts.clone(), Body::from(body_bytes.clone()));
+    let req_for_next = Request::from_parts(req_parts, Body::from(body_bytes));
+
+    let res = next.run(req_for_next).await;
+
+    let (res_parts, res_body) = res.into_parts();
+    let body_bytes = axum::body::to_bytes(res_body, usize::MAX).await.unwrap();
+    eprintln!(
+        "<- {} {}",
+        res_parts.status,
+        String::from_utf8(body_bytes.to_vec()).unwrap_or_else(|_| "<bytes>".to_string())
+    );
+    let res_for_history = Response::from_parts(res_parts.clone(), Body::from(body_bytes.clone()));
+    let res_for_next = Response::from_parts(res_parts, Body::from(body_bytes));
+
+    data.lock()
+        .await
+        .history
+        .push((req_for_history, res_for_history));
+
+    Ok(res_for_next)
+}


### PR DESCRIPTION
The generic artifacts server:
- doesn't require authentication.
- has a certain folder structure
  /artifacts/products/{product}/releases/{release}/package
- redirects routes used by v1 of the download server api
