### PR TITLE
Fix nightly warning

### DIFF
--- a/crates/criticalup-core/src/state.rs
+++ b/crates/criticalup-core/src/state.rs
@@ -185,7 +185,7 @@ impl State {
     }
 
     /// Gets all the installations listed in the `State` file.
-    pub fn installations(&self) -> Ref<BTreeMap<InstallationId, StateInstallation>> {
+    pub fn installations(&self) -> Ref<'_, BTreeMap<InstallationId, StateInstallation>> {
         Ref::map(self.inner.borrow(), |v| &v.repr.installations)
     }
 


### PR DESCRIPTION
This commit can be replicated by running `cargo fix` with rustc 1.91.0-nightly (12eb345e5 2025-09-07).

---

Previously, rustc complained:
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> crates/criticalup-core/src/state.rs:188:26
    |
188 |     pub fn installations(&self) -> Ref<BTreeMap<InstallationId, StateInstallation>> {
    |                          ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                          |
    |                          the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
188 |     pub fn installations(&self) -> Ref<'_, BTreeMap<InstallationId, StateInstallation>> {
    |                                        +++
```