### PR TITLE
Make rust-src part of the criticalup init defaults

### DIFF
--- a/crates/criticalup-core/src/project_manifest/v1.rs
+++ b/crates/criticalup-core/src/project_manifest/v1.rs
@@ -27,6 +27,7 @@ pub fn sample_manifest(release: String) -> ProjectManifest {
         "clippy-${rustc-host}".into(),
         "rust-std-${rustc-host}".into(),
         "rustfmt-${rustc-host}".into(),
+        "rust-src".into(),
     ];
 
     let product = ProjectManifestProduct { release, packages };


### PR DESCRIPTION
While testing the 26.02 beta I noticed that we didn't include `rust-src` in the default manifest. It's probably a good idea to include this as `rust-analyzer` gives warnings/errors if we don't.