### PR TITLE
RA should be proxied correctly in the next release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             manifest-version = 1
 
             [products.ferrocene]
-            release = "stable-24.11.0"
+            release = "stable-24.11.0" # next stable 26.02
             packages = [
                 "cargo-\${rustc-host}",
                 "rustc-\${rustc-host}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
                 "cargo-\${rustc-host}",
                 "rustc-\${rustc-host}",
                 "rust-std-\${rustc-host}",
+             #  "rust-analyzer-\${rustc-host}", # RA has been proxied for version 1.95, it should work for 26.02 stable release
             ]
           EOF
 
@@ -116,6 +117,7 @@ jobs:
           ./criticalup run -- cargo build
           ./criticalup run -- cargo run
           ./criticalup which rustc
+      #   ./criticalup which rust-analyzer
 
       # Windows allows the `.exe` or not, at the users option.
       - name: Run Windows exclusive commands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,23 @@ jobs:
         working-directory: crab-boil
         run: |
           ./criticalup link create
+          
+      # This part of CI will work when 1.95 (26.02) is released as stable
+      - name: Make rust-toolchain file to test rust-analyzer
+        working-directory: crab-boil
+        run: |
+          cat <<- EOF > rust-toolchain.toml
+          [toolchain]
+          channel = "ferrocene"
+          components = ["cargo", "rustfmt", "clippy", "rust-analyzer"]
+          profile = "default"
+          EOF
+
+      - name: Test RA is proxied
+        working-directory: crab-boil
+        run: |
+          which rust-analyzer
+          rust-analyzer --version
 
       - name: Run `criticalup run` test workflow
         working-directory: crab-boil
@@ -117,7 +134,6 @@ jobs:
           ./criticalup run -- cargo build
           ./criticalup run -- cargo run
           ./criticalup which rustc
-      #   ./criticalup which rust-analyzer
 
       # Windows allows the `.exe` or not, at the users option.
       - name: Run Windows exclusive commands

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
                 "cargo-\${rustc-host}",
                 "rustc-\${rustc-host}",
                 "rust-std-\${rustc-host}",
+                "rust-analyzer-\${rustc-host}",
+                "rust-src",
             ]
           EOF
 
@@ -116,6 +118,12 @@ jobs:
         working-directory: crab-boil
         run: |
           ./criticalup link create
+
+      - name: Test RA is proxied
+        working-directory: crab-boil
+        run: |
+          which rust-analyzer
+          rust-analyzer +ferrocene --version
 
       - name: Run `criticalup run` test workflow
         working-directory: crab-boil

--- a/criticalup.toml
+++ b/criticalup.toml
@@ -11,4 +11,6 @@ packages = [
     "clippy-${rustc-host}",
     "rustfmt-${rustc-host}",
     "rust-std-${rustc-host}",
+    "rust-analyzer-${rustc-host}",
+    "rust-src",
 ]


### PR DESCRIPTION
The fix to correctly proxy `rust-analyzer` is first available in stable-26.05
Adds a test confirming rust-analyzer is properly installed via Ferrocene
