### PR TITLE
Signing criticalup Linux binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,16 @@ jobs:
       - name: Build ${{ inputs.release && '(Release)' || '(Debug)'}}
         run: cargo ${{ runner.os == 'Linux' && 'zigbuild' || 'build' }} --package criticalup --target ${{ inputs.target }}${{ inputs.glibc != '' && format('.{0}', inputs.glibc) || '' }} ${{ inputs.release && '--release' || ''}}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        with:
+          cosign-release: 'v3.0.4'
+
+      - name: Sign release binaries
+        # for this release we focus on Linux bins
+        if: ${{ runner.os == 'Linux' }}
+        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle ${{inputs.target}}.sigstore.json
+        
       - name: Prepare archive
         run: |
           mkdir criticalup-${{ inputs.target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,6 @@ jobs:
       package-id: ${{ steps.package.outputs.artifact-id }}
       sha256sum-id: ${{ steps.sha256sum.outputs.artifact-id }}
 
-    permissions:
-      id-token: write
-      
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Sign release binaries
         if: ${{ inputs.release && runner.os == 'Linux' }}
         # for this release we focus on Linux bins
-        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.target }}/criticalup --yes --bundle criticalup.sigstore.json
+        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' }}/criticalup --yes --bundle criticalup.sigstore.json
 
       - name: Prepare archive
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Sign release binaries
         # for this release we focus on Linux bins
         if: ${{ runner.os == 'Linux' }}
-        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle ${{inputs.target}}.sigstore.json
+        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle criticalup.sigstore.json
         
       - name: Prepare archive
         shell: bash
@@ -131,8 +131,8 @@ jobs:
           cp CHANGELOG.md criticalup-${{ inputs.target }}/CHANGELOG.md
 
           # Copying signature bundle if it is created
-          if [-f ${{inputs.target}}.sigstore.json]; then
-            cp ${{inputs.target}}.sigstore.json criticalup-${{ inputs.target }}/${{inputs.target}}.sigstore.json
+          if [-f criticalup.sigstore.json]; then
+            cp criticalup.sigstore.json criticalup-${{ inputs.target }}/criticalup.sigstore.json
           fi 
 
       - name: Make archive (tar.xz)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
           cp CHANGELOG.md criticalup-${{ inputs.target }}/CHANGELOG.md
 
           # Copying signature bundle if it is created
-          if [-f criticalup.sigstore.json]; then
+          if [[ -f criticalup.sigstore.json ]]; then
             cp criticalup.sigstore.json criticalup-${{ inputs.target }}/criticalup.sigstore.json
           fi 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Sign release binaries
         if: ${{ inputs.release && runner.os == 'Linux' }}
         # for this release we focus on Linux bins
-        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' }}/criticalup --yes --bundle criticalup.sigstore.json
+        run:  cosign sign-blob target/${{ inputs.target }}/release/criticalup --yes --bundle criticalup.sigstore.json
 
       - name: Prepare archive
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,11 +123,17 @@ jobs:
         run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle ${{inputs.target}}.sigstore.json
         
       - name: Prepare archive
+        shell: bash
         run: |
           mkdir criticalup-${{ inputs.target }}
           cp target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup criticalup-${{ inputs.target }}/criticalup${{ (runner.os == 'Windows' && '.exe') || '' }}
           cp crates/criticalup/README.md criticalup-${{ inputs.target }}/README.md
           cp CHANGELOG.md criticalup-${{ inputs.target }}/CHANGELOG.md
+
+          # Copying signature bundle if it is created
+          if [-f ${{inputs.target}}.sigstore.json]; then
+            cp ${{inputs.target}}.sigstore.json criticalup-${{ inputs.target }}/${{inputs.target}}.sigstore.json
+          fi 
 
       - name: Make archive (tar.xz)
         if: ${{ runner.os == 'Linux' || runner.os == 'macOS' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Sign release binaries
         if: ${{ inputs.release && runner.os == 'Linux' }}
         # for this release we focus on Linux bins
-        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release }}/criticalup --yes --bundle criticalup.sigstore.json
-        
+        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.target }}/criticalup --yes --bundle criticalup.sigstore.json
+
       - name: Prepare archive
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Sign release binaries
         if: ${{ inputs.release && runner.os == 'Linux' }}
         # for this release we focus on Linux bins
-        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle criticalup.sigstore.json
+        run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release }}/criticalup --yes --bundle criticalup.sigstore.json
         
       - name: Prepare archive
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,9 +118,8 @@ jobs:
           cosign-release: 'v3.0.4'
 
       - name: Sign release binaries
-        if: ${{ inputs.release }}
+        if: ${{ inputs.release && runner.os == 'Linux' }}
         # for this release we focus on Linux bins
-        if: ${{ runner.os == 'Linux' }}
         run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle criticalup.sigstore.json
         
       - name: Prepare archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,10 @@ jobs:
     outputs:
       package-id: ${{ steps.package.outputs.artifact-id }}
       sha256sum-id: ${{ steps.sha256sum.outputs.artifact-id }}
+
+    permissions:
+      id-token: write
+      
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
       release:
         type: boolean
         default: false
-        description: If the package should be built in release mode
+        description: If the package should be built in release mode, and Linux binaries signed
       test:
         type: boolean
         default: true
@@ -43,7 +43,6 @@ on:
 defaults:
   run:
     shell: bash
-
 
 jobs:
   build:
@@ -113,11 +112,13 @@ jobs:
         run: cargo ${{ runner.os == 'Linux' && 'zigbuild' || 'build' }} --package criticalup --target ${{ inputs.target }}${{ inputs.glibc != '' && format('.{0}', inputs.glibc) || '' }} ${{ inputs.release && '--release' || ''}}
 
       - name: Install cosign
+        if: ${{ inputs.release }}
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: 'v3.0.4'
 
       - name: Sign release binaries
+        if: ${{ inputs.release }}
         # for this release we focus on Linux bins
         if: ${{ runner.os == 'Linux' }}
         run:  cosign sign-blob target/${{ inputs.target }}/${{ inputs.release && 'release' || 'debug' }}/criticalup --yes --bundle criticalup.sigstore.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,11 @@ jobs:
           ./criticalup remove
           ./criticalup clean
 
-  # package:
-  #   secrets: inherit
-  #   uses: ./.github/workflows/package.yml
-  #   with:
-  #     sign: false
+  package:
+    secrets: inherit
+    uses: ./.github/workflows/package.yml
+    with:
+      sign: false
 
   license:
     name: Check licenses
@@ -174,7 +174,7 @@ jobs:
     needs:
       - build
       - integration-test
-      # - package
+      - package
       - docs
       - license
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ name: CI
 on:
   push:
     branches: [staging, trying]
-  workflow_dispatch: {}
 
 permissions:
   # Allow write access to the source code to enable GitHub Pages publishing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         include:
@@ -34,6 +37,7 @@ jobs:
       target: ${{ matrix.target }}
       glibc: ${{ matrix.glibc }}
       release: false
+
 
   integration-test:
     name: Test CriticalUp on GHA Runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: CI
 on:
   push:
     branches: [staging, trying]
-  workflow-dispatch: {}
+  workflow_dispatch: {}
 
 permissions:
   # Allow write access to the source code to enable GitHub Pages publishing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ name: CI
 on:
   push:
     branches: [staging, trying]
+  workflow-dispatch: {}
 
 permissions:
   # Allow write access to the source code to enable GitHub Pages publishing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,11 @@ jobs:
           ./criticalup remove
           ./criticalup clean
 
-  package:
-    secrets: inherit
-    uses: ./.github/workflows/package.yml
-    with:
-      sign: false
+  # package:
+  #   secrets: inherit
+  #   uses: ./.github/workflows/package.yml
+  #   with:
+  #     sign: false
 
   license:
     name: Check licenses
@@ -174,7 +174,7 @@ jobs:
     needs:
       - build
       - integration-test
-      - package
+      # - package
       - docs
       - license
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,12 @@ jobs:
           ./criticalup remove
           ./criticalup clean
 
-  package:
-    secrets: inherit
-    uses: ./.github/workflows/package.yml
-    with:
-      sign: false
+  # Commenting out to test #168
+  # package:
+  #   secrets: inherit
+  #   uses: ./.github/workflows/package.yml
+  #   with:
+  #     sign: false
 
   license:
     name: Check licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,12 +148,11 @@ jobs:
           ./criticalup remove
           ./criticalup clean
 
-  # Commenting out to test #168
-  # package:
-  #   secrets: inherit
-  #   uses: ./.github/workflows/package.yml
-  #   with:
-  #     sign: false
+  package:
+    secrets: inherit
+    uses: ./.github/workflows/package.yml
+    with:
+      sign: false
 
   license:
     name: Check licenses

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,24 +38,24 @@ jobs:
       glibc: ${{ matrix.glibc }}
       release: true
 
-  # package:
-  #   secrets: inherit
-  #   uses: ./.github/workflows/package.yml
-  #   with:
-  #     sign: true
+  package:
+    secrets: inherit
+    uses: ./.github/workflows/package.yml
+    with:
+      sign: true
 
   deploy-docs:
     secrets: inherit
     needs:
       - build
-      # - package
+      - package
     uses: ./.github/workflows/deploy-docs.yml
 
   release:
     runs-on: ubuntu-latest
     needs:
       - build
-      # - package
+      - package
       - deploy-docs
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
 
       - name: List artifacts
         shell: nu {0}
-        run: ls 
+        run: |
+          cd artifacts
+          ls 
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
           mkdir artifacts
           open ci/criticalup-installer.ps1 | str replace --all "%REPLACE_VERSION%" "${{ steps.metadata.outputs.VERSION }}" | save -a artifacts/criticalup-installer.ps1
           open ci/criticalup-installer.sh | str replace --all "%REPLACE_VERSION%" "${{ steps.metadata.outputs.VERSION }}" | save -a artifacts/criticalup-installer.sh
-          
           open ci/install-instructions.md | str replace --all "%REPLACE_VERSION%" "${{ steps.metadata.outputs.VERSION }}" | save -a install-instructions.md
 
       - name: Upload powershell installer
@@ -109,6 +108,10 @@ jobs:
           path: artifacts
           pattern: criticalup-*
           merge-multiple: true
+
+      - name: List artifacts
+        shell: nu {0}
+        run: ls 
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,11 @@ jobs:
       glibc: ${{ matrix.glibc }}
       release: true
 
-  # Commenting out to test #168
-  # package:
-  #   secrets: inherit
-  #   uses: ./.github/workflows/package.yml
-  #   with:
-  #     sign: true
+  package:
+    secrets: inherit
+    uses: ./.github/workflows/package.yml
+    with:
+      sign: true
 
   deploy-docs:
     secrets: inherit
@@ -83,6 +82,7 @@ jobs:
           mkdir artifacts
           open ci/criticalup-installer.ps1 | str replace --all "%REPLACE_VERSION%" "${{ steps.metadata.outputs.VERSION }}" | save -a artifacts/criticalup-installer.ps1
           open ci/criticalup-installer.sh | str replace --all "%REPLACE_VERSION%" "${{ steps.metadata.outputs.VERSION }}" | save -a artifacts/criticalup-installer.sh
+          
           open ci/install-instructions.md | str replace --all "%REPLACE_VERSION%" "${{ steps.metadata.outputs.VERSION }}" | save -a install-instructions.md
 
       - name: Upload powershell installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,24 +38,24 @@ jobs:
       glibc: ${{ matrix.glibc }}
       release: true
 
-  package:
-    secrets: inherit
-    uses: ./.github/workflows/package.yml
-    with:
-      sign: true
+  # package:
+  #   secrets: inherit
+  #   uses: ./.github/workflows/package.yml
+  #   with:
+  #     sign: true
 
   deploy-docs:
     secrets: inherit
     needs:
       - build
-      - package
+      # - package
     uses: ./.github/workflows/deploy-docs.yml
 
   release:
     runs-on: ubuntu-latest
     needs:
       - build
-      - package
+      # - package
       - deploy-docs
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,12 @@ jobs:
       glibc: ${{ matrix.glibc }}
       release: true
 
-  package:
-    secrets: inherit
-    uses: ./.github/workflows/package.yml
-    with:
-      sign: true
+  # Commenting out to test #168
+  # package:
+  #   secrets: inherit
+  #   uses: ./.github/workflows/package.yml
+  #   with:
+  #     sign: true
 
   deploy-docs:
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,12 +109,6 @@ jobs:
           pattern: criticalup-*
           merge-multiple: true
 
-      - name: List artifacts
-        shell: nu {0}
-        run: |
-          cd artifacts
-          ls 
-
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Linux binaries are signed with [`cosign`](https://github.com/sigstore/cosign). The signature can be verified by the user with the following command, using the cert file provided in the archive:
+
+`cosign verify-blob <linux-binary-name> --certificate-identity-regexp ".*" --bundle <linux-binary-name>.sigstore.json --certificate-oidc-issuer https://token.actions.githubusercontent.com`
+
+
 ## 1.6.0 - 2025-09-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ If the release build fails:
 - Revert the changes from `release/vX.Y.Z` and open a PR to be merged to `main`.
 - Delete the tag from GitHub.
 
+
+## Verifying signatures
+
+We use [`cosign`](https://github.com/sigstore/cosign) to verify signatures on Linux platforms.
+Install cosign. Inside the archive, there is a <binary>.sigstore.json certificate.
+Run:
+
+cosign verify-blob <binary-name> \
+    --certificate-identity-regexp ".*" \
+    --bundle <binary-name>.sigstore.json \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+
 ## Using ferrocene as default toolchain
 
 To use `ferrocene` as the default `rustup` toolchain, it is possible to create a `rust-toolchain.toml` file at the root:


### PR DESCRIPTION
This PR signes Linux binaries with `cosign` , and uploads the cert file.
Permissions are necessary to create temporary [OIDC tokens](https://docs.github.com/en/actions/concepts/security/openid-connect#benefits-of-using-oidc).


Possible improvement in the future: we want to separate building from signing. We must move [signing Linux jobs](https://github.com/ferrocene/criticalup/blob/8fd124cab5daecac12deb7da48173bb133d73376/.github/workflows/build.yml#L104-L149) in their own workflow.