### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,11 @@ ARG TARGET_UBUNTU_VERSION=24.04
 
 #
 # As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
-FROM ubuntu:$TARGET_UBUNTU_VERSION
+FROM ubuntu:$TARGET_UBUNTU_VERSION AS ferrocene_builder
 
-ARG TARGETPLATFORM
 ARG TARGET_UBUNTU_VERSION=20.04
-ARG BUILDPLATFORM
 ARG CRITICALUP_RELEASE=1.6.0
 ARG FERROCENE_RELEASE
-ARG RUNNER_VERSION
 
 USER root
 
@@ -55,25 +52,14 @@ RUN --mount=type=secret,id=criticalup_token,env=CRITICALUP_TOKEN <<-EOF
 
   cat criticalup.toml
 
-  if [[ "$TARGETPLATFORM" = "linux/amd64" ]]; then
-    ARCH="x86_64"
-  elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then
-    ARCH="aarch64"
-  else
-    echo "Unknown target platform $TARGETPLATFORM"
-    exit 1
-  fi
-
-  # add musl targets for those releases that support them
-  VERSION_NUMBER=$(echo "$FERROCENE_RELEASE"  | cut -f 2 -d "-")
-  if [[ "$VERSION_NUMBER" > "25.08.0" ]]; then
-    sed "/^]/i\\    \"rust-std-$ARCH-unknown-linux-musl\"," -i criticalup.toml
-  fi;
-
-  cat criticalup.toml
   criticalup auth set $CRITICALUP_TOKEN
   criticalup install
   criticalup auth remove
 EOF
 
 CMD ["sh", "-c", "echo 'This image is intended for multi-stage builds only.' >&2; exit 1"]
+
+FROM ubuntu:$TARGET_UBUNTU_VERSION AS example
+
+COPY --from=0 /root/.cache/criticalup/artifacts artifacts
+CMD ["/usr/bin/ls", "-R", "artifacts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-FileCopyrightText: The Ferrocene Developers
+
+# This is built based on stock ubuntu
+
+ARG TARGET_UBUNTU_VERSION=24.04
+
+#
+# As a multiplatform container we support all these: https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+FROM ubuntu:$TARGET_UBUNTU_VERSION
+
+ARG TARGETPLATFORM
+ARG TARGET_UBUNTU_VERSION=20.04
+ARG BUILDPLATFORM
+ARG CRITICALUP_RELEASE=1.6.0
+ARG FERROCENE_RELEASE
+ARG RUNNER_VERSION
+
+USER root
+
+SHELL [ "bash", "-c" ]
+
+RUN <<-EOF
+    set -xe
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+    apt-get update
+    # Update all the dependencies
+    apt-get upgrade -y
+    # Install required packages
+    apt-get install -yq --no-install-recommends --option Dpkg::Options::=--force-confnew \
+        curl \
+        unzip \
+        xz-utils \
+        ca-certificates
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Tell programs relying on the system language (like Python) to use UTF-8.
+ENV LANG=C.UTF-8
+
+ENV PATH="root/.cargo/bin:$PATH"
+
+# install ferrocene
+
+RUN --mount=type=secret,id=criticalup_token,env=CRITICALUP_TOKEN <<-EOF
+  set -xe
+
+  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ferrocene/criticalup/releases/download/v${CRITICALUP_RELEASE}/criticalup-installer.sh | sh
+
+  # If no criticalup.toml is added to the build, init criticalup.toml with the default configuration
+  if [[ ! -e criticalup.toml ]]; then
+    criticalup init --release $FERROCENE_RELEASE
+  fi
+
+  cat criticalup.toml
+
+  if [[ "$TARGETPLATFORM" = "linux/amd64" ]]; then
+    ARCH="x86_64"
+  elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then
+    ARCH="aarch64"
+  else
+    echo "Unknown target platform $TARGETPLATFORM"
+    exit 1
+  fi
+
+  # add musl targets for those releases that support them
+  VERSION_NUMBER=$(echo "$FERROCENE_RELEASE"  | cut -f 2 -d "-")
+  if [[ "$VERSION_NUMBER" > "25.08.0" ]]; then
+    sed "/^]/i\\    \"rust-std-$ARCH-unknown-linux-musl\"," -i criticalup.toml
+  fi;
+
+  cat criticalup.toml
+  criticalup auth set $CRITICALUP_TOKEN
+  criticalup install
+  criticalup auth remove
+EOF
+
+CMD ["sh", "-c", "echo 'This image is intended for multi-stage builds only.' >&2; exit 1"]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cosign verify-blob <binary-name> \
 To use `ferrocene` as the default `rustup` toolchain, it is possible to create a `rust-toolchain.toml` file at the root:
 
 ```
-> cat rust-toolchain.toml 
+> cat rust-toolchain.toml
 [toolchain]
 channel = "ferrocene"
 components = ["cargo", "rustfmt", "clippy"]
@@ -118,6 +118,35 @@ profile = "default"
 ```
 
 Add the file to `.gitignore`
+
+## Docker image
+
+We provide ./docker/Dockerfile, defining an image that can be used download packages in a multi step docker build.
+Docker with Buidkit enabled is required.
+
+If no configuration file (`criticalup.toml`) is copied into the image, criticalup will initialize one.
+
+The following build-args are available:
+
+FERROCENE_RELEASE  a ferrocene release version
+TARGET_UBUNTU_VERSION an ubuntu version
+CRITICALUP_RELEASE a criticalup release version
+
+The following secret is required:
+criticalup_token
+
+The package tarballs are located in
+` root/.cache/criticalup/artifacts/products/ferrocene/releases/...`
+
+### usage
+
+assuming we have the criticalup TOKEN in an env variable named TOKEN_ENV_VAR
+
+```bash
+docker build --secret id=criticalup_token,env=TOKEN_ENV_VAR --build-arg FERROCENE_RELEASE=stable-26.02.0 . -t ferrocene_builder
+```
+
+and then define a Dockerfile that uses the image in a multi-step setup.
 
 [criticalup-docs]: https://criticalup.ferrocene.dev/
 

--- a/README.md
+++ b/README.md
@@ -121,32 +121,49 @@ Add the file to `.gitignore`
 
 ## Docker image
 
-We provide ./docker/Dockerfile, defining an image that can be used download packages in a multi step docker build.
+We provide ./docker/Dockerfile, defining an image `ferrocene_builder` that can be used download packages in a multi step/multi arch docker build.
 Docker with Buidkit enabled is required.
 
-If no configuration file (`criticalup.toml`) is copied into the image, criticalup will initialize one.
+If no configuration file is copied into the image in a modified Docker file definition (`ADD criticalup.toml .`), criticalup will initialize one.
+On being built, the image prints out the used criticalup.toml. If doubts, pass the (`--no-cache --progress=plain`) flags to the build command  to confirm which configuration is being used.
 
 The following build-args are available:
 
-FERROCENE_RELEASE  a ferrocene release version
-TARGET_UBUNTU_VERSION an ubuntu version
-CRITICALUP_RELEASE a criticalup release version
+`FERROCENE_RELEASE`  a Ferrocene release version
+`TARGET_UBUNTU_VERSION` an Ubuntu version
+`CRITICALUP_RELEASE` a criticalup release version
 
-The following secret is required:
-criticalup_token
+Passing the criticalup secret token is required:
+`criticalup_token` a criticalup token
 
-The package tarballs are located in
+The downloaded package tarballs are located in
 ` root/.cache/criticalup/artifacts/products/ferrocene/releases/...`
 
 ### usage
 
-assuming we have the criticalup TOKEN in an env variable named TOKEN_ENV_VAR
+The [CriticalUp Documentation][criticalup-docs] Authenticating section describes how to generate the criticalup token.
+Assuming we have the criticalup token in an env variable named CRITICALUP_TOKEN.
+
+#### build example image
+
+Build example image, that uses Ferrocene_builder image to copy Ferrocene packages from.
 
 ```bash
-docker build --secret id=criticalup_token,env=TOKEN_ENV_VAR --build-arg FERROCENE_RELEASE=stable-26.02.0 . -t ferrocene_builder
+docker build --secret id=criticalup_token,env=CRITICALUP_TOKEN --build-arg FERROCENE_RELEASE=stable-26.02.0 . -t example
 ```
 
-and then define a Dockerfile that uses the image in a multi-step setup.
+
+`docker run example` recursively lists the downloaded Ferrocene packages.
+
+#### build ferrocene_builder image
+
+Build only the ferrocene_builder image, and then define a Dockerfile that uses the image in a multi-step setup.
+
+```bash
+docker build --from ferrocene_builder --secret id=criticalup_token,env=CRITICALUP_TOKEN --build-arg FERROCENE_RELEASE=stable-26.02.0 . -t ferrocene_builder
+```
+
+
 
 [criticalup-docs]: https://criticalup.ferrocene.dev/
 


### PR DESCRIPTION
Adds a Dockerfile **example** intended for building images that can be used in multi-step multi-arch docker builds
Follow the `usage` section in the added instructions to test this manually. 
Building the image in CI and pushing it to a repository is out of the scope of this task.
