### PR TITLE
warn when cargo subcommand backing binary is not part of the criticalup installation

### DIFF
--- a/crates/criticalup-cli/src/cli/subcommand/run.rs
+++ b/crates/criticalup-cli/src/cli/subcommand/run.rs
@@ -9,6 +9,7 @@ use crate::cli::CommandExecute;
 use crate::errors::Error;
 use crate::spawn::spawn_command;
 use crate::Context;
+use std::collections::HashMap;
 use std::env::current_dir;
 use std::path::PathBuf;
 // We *deliberately* use a sync Command here, since we are spawning a process to replace the current one.
@@ -112,6 +113,23 @@ impl CommandExecute for Run {
                 return Err(Error::BinaryNotInstalled(
                     binary.to_string_lossy().to_string(),
                 ));
+            }
+        }
+
+        // Warns if ARG is 'clippy' or 'fmt' in `criticalup run cargo <ARG>` and the subcommand backing executable is not part of the
+        // criticalup installation.
+
+        let mut cargo_subcommand_map = HashMap::new();
+        cargo_subcommand_map.insert("clippy", "cargo-clippy");
+        cargo_subcommand_map.insert("fmt", "rustfmt");
+
+        for arg in args {
+            if let Some(backing_binary) = cargo_subcommand_map.get(arg.as_str()) {
+                if !bin_paths.iter().any(|x| x.join(backing_binary).exists()) {
+                    tracing::warn!("'{0}' is not installed for this project, and may run from binaries outside the criticalup installation.\n \
+                    To prevent this, please make sure that the correct package for '{0}' is listed in the packages section of your \n\
+                    project's criticalup.toml and run 'criticalup install' command again.\n",  backing_binary);
+                }
             }
         }
 

--- a/crates/criticalup-cli/src/cli/subcommand/run.rs
+++ b/crates/criticalup-cli/src/cli/subcommand/run.rs
@@ -10,6 +10,7 @@ use crate::errors::Error;
 use crate::spawn::spawn_command;
 use crate::Context;
 use std::collections::HashMap;
+use std::env::consts::EXE_SUFFIX;
 use std::env::current_dir;
 use std::path::PathBuf;
 // We *deliberately* use a sync Command here, since we are spawning a process to replace the current one.
@@ -120,8 +121,8 @@ impl CommandExecute for Run {
         // criticalup installation.
 
         let mut cargo_subcommand_map = HashMap::new();
-        cargo_subcommand_map.insert("clippy", "cargo-clippy");
-        cargo_subcommand_map.insert("fmt", "rustfmt");
+        cargo_subcommand_map.insert("clippy", format!("cargo-clippy{}", EXE_SUFFIX));
+        cargo_subcommand_map.insert("fmt", format!("rustfmt{}", EXE_SUFFIX));
 
         for arg in args {
             if let Some(backing_binary) = cargo_subcommand_map.get(arg.as_str()) {

--- a/crates/criticalup-cli/tests/cli/run.rs
+++ b/crates/criticalup-cli/tests/cli/run.rs
@@ -58,7 +58,7 @@ async fn simple_run_command_existing_package() {
         release = \"nightly\"
         packages = [\"sample\"]
         ";
-    std::fs::write(&manifest, project_manifest.as_bytes(),) .unwrap();
+    std::fs::write(&manifest, project_manifest.as_bytes()).unwrap();
 
     let installation_id =
         ProjectManifest::load(current_dir.path().join("criticalup.toml").as_path())
@@ -100,9 +100,167 @@ async fn simple_run_command_existing_package() {
     let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
     f.write_all(b"").unwrap();
 
-    assert_output!(test_env.cmd().args(["run",
+    assert_output!(test_env
+        .cmd()
+        .args(["run", "--project", manifest.to_str().unwrap(), "sample",]));
+}
+
+#[tokio::test]
+async fn cargo_clippy_command_clippy_package_missing() {
+    let test_env = TestEnvironment::prepare().await;
+    let current_dir = tempdir().unwrap();
+    std::fs::create_dir_all(test_env.root().join("bin")).unwrap();
+    let manifest = current_dir.path().join("criticalup.toml");
+
+    let project_manifest = "
+        manifest-version = 1
+        [products.ferrocene]
+        release = \"nightly\"
+        packages = [\"cargo\", \"clippy\"]
+        ";
+    std::fs::write(&manifest, project_manifest.as_bytes()).unwrap();
+
+    let installation_id =
+        ProjectManifest::load(current_dir.path().join("criticalup.toml").as_path())
+            .unwrap()
+            .products()
+            .first()
+            .unwrap()
+            .installation_id()
+            .0;
+    // Create a sample state file referencing the binary proxy.
+    std::fs::write(
+        test_env.root().join("state.json"),
+        serde_json::json!({
+            "version": 1,
+            "installations": {
+                &installation_id: {
+                    "manifests": ["/path/to/manifest/a", "/path/to/manifest/b"],
+                    "binary_proxies": {
+                    },
+                },
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    )
+    .unwrap();
+
+    // Create a cargo mocking binary.
+    crate::binary_proxies::compile_to(
+        &test_env
+            .root()
+            .join("toolchains")
+            .join(&installation_id)
+            .join("bin")
+            .join("cargo"),
+        r#"fn main() { println!("success: cargo binary was called via run command"); }"#,
+    );
+    let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
+    f.write_all(b"").unwrap();
+
+    // clippy is missing, in strict and no-strict mode this should return a warning message in the snapshot
+    assert_output!(test_env.cmd().args([
+        "run",
         "--project",
         manifest.to_str().unwrap(),
-        "sample",
+        "--strict",
+        "cargo",
+        "clippy",
+    ]));
+
+    assert_output!(test_env.cmd().args([
+        "run",
+        "--project",
+        manifest.to_str().unwrap(),
+        "cargo",
+        "clippy",
+    ]));
+}
+
+#[tokio::test]
+async fn cargo_clippy_command_existing_packages() {
+    let test_env = TestEnvironment::prepare().await;
+    let current_dir = tempdir().unwrap();
+    std::fs::create_dir_all(test_env.root().join("bin")).unwrap();
+    let manifest = current_dir.path().join("criticalup.toml");
+
+    let project_manifest = "
+        manifest-version = 1
+        [products.ferrocene]
+        release = \"nightly\"
+        packages = [\"cargo\", \"clippy\"]
+        ";
+    std::fs::write(&manifest, project_manifest.as_bytes()).unwrap();
+
+    let installation_id =
+        ProjectManifest::load(current_dir.path().join("criticalup.toml").as_path())
+            .unwrap()
+            .products()
+            .first()
+            .unwrap()
+            .installation_id()
+            .0;
+
+    // Create a sample state file referencing the binary proxy.
+    std::fs::write(
+        test_env.root().join("state.json"),
+        serde_json::json!({
+            "version": 1,
+            "installations": {
+                &installation_id: {
+                    "manifests": ["/path/to/manifest/a", "/path/to/manifest/b"],
+                    "binary_proxies": {
+                    },
+                },
+            },
+        })
+        .to_string()
+        .as_bytes(),
+    )
+    .unwrap();
+
+    // Create a cargo mocking binary.
+    crate::binary_proxies::compile_to(
+        &test_env
+            .root()
+            .join("toolchains")
+            .join(&installation_id)
+            .join("bin")
+            .join("cargo"),
+        r#"fn main() { println!("success: cargo binary was called via run command"); }"#,
+    );
+    let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
+    f.write_all(b"").unwrap();
+
+    // Create a clippy mocking binary.
+    crate::binary_proxies::compile_to(
+        &test_env
+            .root()
+            .join("toolchains")
+            .join(&installation_id)
+            .join("bin")
+            .join("cargo-clippy"),
+        r#"fn main() { println!("success: cargo-clippy binary was called via run command"); }"#,
+    );
+
+    // both cargo and clippy binaries are present,
+    // this will run cargo binary, in strict and non strict mode.
+    // No warning about not intsalled binary is emited.
+    assert_output!(test_env.cmd().args([
+        "run",
+        "--project",
+        manifest.to_str().unwrap(),
+        "--strict",
+        "cargo",
+        "clippy",
+    ]));
+
+    assert_output!(test_env.cmd().args([
+        "run",
+        "--project",
+        manifest.to_str().unwrap(),
+        "cargo",
+        "clippy",
     ]));
 }

--- a/crates/criticalup-cli/tests/cli/run.rs
+++ b/crates/criticalup-cli/tests/cli/run.rs
@@ -46,11 +46,11 @@ async fn simple_run_command_did_not_run_install() {
 }
 
 #[tokio::test]
-#[ignore = "This test will be improved upon at a later date"]
 async fn simple_run_command_existing_package() {
     let test_env = TestEnvironment::prepare().await;
     let current_dir = tempdir().unwrap();
     std::fs::create_dir_all(test_env.root().join("bin")).unwrap();
+    let manifest = current_dir.path().join("criticalup.toml");
 
     let project_manifest = "
         manifest-version = 1
@@ -58,11 +58,7 @@ async fn simple_run_command_existing_package() {
         release = \"nightly\"
         packages = [\"sample\"]
         ";
-    std::fs::write(
-        current_dir.path().join("criticalup.toml"),
-        project_manifest.as_bytes(),
-    )
-    .unwrap();
+    std::fs::write(&manifest, project_manifest.as_bytes(),) .unwrap();
 
     let installation_id =
         ProjectManifest::load(current_dir.path().join("criticalup.toml").as_path())
@@ -104,20 +100,9 @@ async fn simple_run_command_existing_package() {
     let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
     f.write_all(b"").unwrap();
 
-    let mut c = std::process::Command::new(
-        test_env
-            .root()
-            .join("toolchains")
-            .join(&installation_id)
-            .join("bin")
-            .join("sample")
-            .as_os_str()
-            .to_str()
-            .unwrap(),
-    );
-    std::io::stdout()
-        .write_all(&c.output().unwrap().stdout)
-        .unwrap();
-
-    // assert_output!(test_env.cmd().args(["run", "sample"]));
+    assert_output!(test_env.cmd().args(["run",
+        "--project",
+        manifest.to_str().unwrap(),
+        "sample",
+    ]));
 }

--- a/crates/criticalup-cli/tests/cli/run.rs
+++ b/crates/criticalup-cli/tests/cli/run.rs
@@ -4,6 +4,7 @@
 use crate::assert_output;
 use crate::utils::TestEnvironment;
 use criticalup_core::project_manifest::ProjectManifest;
+use std::env::consts::EXE_SUFFIX;
 use std::io::Write;
 use tempfile::tempdir;
 
@@ -69,6 +70,7 @@ async fn simple_run_command_existing_package() {
             .installation_id()
             .0;
     // Create a sample state file referencing the binary proxy.
+
     std::fs::write(
         test_env.root().join("state.json"),
         serde_json::json!({
@@ -94,7 +96,7 @@ async fn simple_run_command_existing_package() {
             .join("toolchains")
             .join(&installation_id)
             .join("bin")
-            .join("sample"),
+            .join(format!("sample{}", EXE_SUFFIX)),
         r#"fn main() { println!("success: sample binary was called via run command"); }"#,
     );
     let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
@@ -137,6 +139,7 @@ async fn cargo_clippy_command_clippy_package_missing() {
                 &installation_id: {
                     "manifests": ["/path/to/manifest/a", "/path/to/manifest/b"],
                     "binary_proxies": {
+                        "cargo": format!("bin/cargo{}", EXE_SUFFIX),
                     },
                 },
             },
@@ -146,6 +149,10 @@ async fn cargo_clippy_command_clippy_package_missing() {
     )
     .unwrap();
 
+    let mut f =
+        std::fs::File::create(test_env.root().join(format!("bin/cargo{}", EXE_SUFFIX))).unwrap();
+    f.write_all(b"").unwrap();
+
     // Create a cargo mocking binary.
     crate::binary_proxies::compile_to(
         &test_env
@@ -153,11 +160,9 @@ async fn cargo_clippy_command_clippy_package_missing() {
             .join("toolchains")
             .join(&installation_id)
             .join("bin")
-            .join("cargo"),
+            .join(format!("cargo{}", EXE_SUFFIX)),
         r#"fn main() { println!("success: cargo binary was called via run command"); }"#,
     );
-    let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
-    f.write_all(b"").unwrap();
 
     // clippy is missing, in strict and no-strict mode this should return a warning message in the snapshot
     assert_output!(test_env.cmd().args([
@@ -211,6 +216,8 @@ async fn cargo_clippy_command_existing_packages() {
                 &installation_id: {
                     "manifests": ["/path/to/manifest/a", "/path/to/manifest/b"],
                     "binary_proxies": {
+                        "cargo": format!("bin/cargo{}", EXE_SUFFIX),
+                        "clippy": format!("bin/cargo-clippy{}", EXE_SUFFIX),
                     },
                 },
             },
@@ -221,32 +228,42 @@ async fn cargo_clippy_command_existing_packages() {
     .unwrap();
 
     // Create a cargo mocking binary.
+
     crate::binary_proxies::compile_to(
         &test_env
             .root()
             .join("toolchains")
             .join(&installation_id)
             .join("bin")
-            .join("cargo"),
+            .join(format!("cargo{}", EXE_SUFFIX)),
         r#"fn main() { println!("success: cargo binary was called via run command"); }"#,
     );
-    let mut f = std::fs::File::create(test_env.root().join("bin/sample")).unwrap();
-    f.write_all(b"").unwrap();
 
-    // Create a clippy mocking binary.
     crate::binary_proxies::compile_to(
         &test_env
             .root()
             .join("toolchains")
             .join(&installation_id)
             .join("bin")
-            .join("cargo-clippy"),
+            .join(format!("cargo-clippy{}", EXE_SUFFIX)),
         r#"fn main() { println!("success: cargo-clippy binary was called via run command"); }"#,
     );
 
+    let mut f =
+        std::fs::File::create(test_env.root().join(format!("bin/cargo{}", EXE_SUFFIX))).unwrap();
+    f.write_all(b"").unwrap();
+
+    let mut t = std::fs::File::create(
+        test_env
+            .root()
+            .join(format!("bin/cargo-clippy{}", EXE_SUFFIX)),
+    )
+    .unwrap();
+    t.write_all(b"").unwrap();
+
     // both cargo and clippy binaries are present,
     // this will run cargo binary, in strict and non strict mode.
-    // No warning about not intsalled binary is emited.
+    // No warning about not installed binary is emitted.
     assert_output!(test_env.cmd().args([
         "run",
         "--project",

--- a/crates/criticalup-cli/tests/cli/utils.rs
+++ b/crates/criticalup-cli/tests/cli/utils.rs
@@ -292,6 +292,7 @@ macro_rules! assert_output {
         settings.add_filter(r"bin\\rustc", r"bin/rustc");
         #[cfg(windows)]
         settings.add_filter("criticalup-test.exe", "criticalup-test");
+        settings.add_filter("cargo-clippy.exe", "cargo-clippy");
 
         settings.add_filter(r"INFO Created project manifest at .+criticalup\.toml", "INFO Created project manifest at /path/to/created/criticalup.toml");
 

--- a/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_clippy_package_missing-2.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_clippy_package_missing-2.snap
@@ -1,0 +1,18 @@
+---
+source: crates/criticalup-cli/tests/cli/run.rs
+expression: repr
+---
+exit: exit status: 0
+
+stdout
+------
+success: cargo binary was called via run command
+------
+
+stderr
+------
+ WARN 'cargo-clippy' is not installed for this project, and may run from binaries outside the criticalup installation.
+ To prevent this, please make sure that the correct package for 'cargo-clippy' is listed in the packages section of your 
+project's criticalup.toml and run 'criticalup install' command again.
+
+------

--- a/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_clippy_package_missing.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_clippy_package_missing.snap
@@ -1,0 +1,18 @@
+---
+source: crates/criticalup-cli/tests/cli/run.rs
+expression: repr
+---
+exit: exit status: 0
+
+stdout
+------
+success: cargo binary was called via run command
+------
+
+stderr
+------
+ WARN 'cargo-clippy' is not installed for this project, and may run from binaries outside the criticalup installation.
+ To prevent this, please make sure that the correct package for 'cargo-clippy' is listed in the packages section of your 
+project's criticalup.toml and run 'criticalup install' command again.
+
+------

--- a/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_existing_packages-2.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_existing_packages-2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/criticalup-cli/tests/cli/run.rs
+expression: repr
+---
+exit: exit status: 0
+
+stdout
+------
+success: cargo binary was called via run command
+------
+
+empty stderr

--- a/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_existing_packages.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__cargo_clippy_command_existing_packages.snap
@@ -1,0 +1,12 @@
+---
+source: crates/criticalup-cli/tests/cli/run.rs
+expression: repr
+---
+exit: exit status: 0
+
+stdout
+------
+success: cargo binary was called via run command
+------
+
+empty stderr

--- a/crates/criticalup-cli/tests/snapshots/cli__run__simple_run_command_existing_package.snap
+++ b/crates/criticalup-cli/tests/snapshots/cli__run__simple_run_command_existing_package.snap
@@ -1,0 +1,12 @@
+---
+source: crates/criticalup-cli/tests/cli/run.rs
+expression: repr
+---
+exit: exit status: 0
+
+stdout
+------
+success: sample binary was called via run command
+------
+
+empty stderr


### PR DESCRIPTION
Emits a warning if:
- `criticalup run (--strict) cargo clippy` is run  but `cargo-clippy` is not installed via criticalup. 
- `criticalup run (--strict) cargo fmt` is run but `rustfmt` is not installed via criticalup. 


Problem
------------

When clippy is available via  rustup, but not installed via Ferrocene, running
`criticalup run cargo clippy`  will fallback to using rustup's  installed clippy , potentially resulting in crates compiled with an incompatible version of rustc (compared to the version clippy was compiled with).

Replication steps
-------------------------

1. Install rustup stable
2. install Ferrocene packages via criticalup, with the following configuration, which doesn't include clippy 

```
manifest-version = 1

[products.ferrocene]
release = "stable-25.08.0"
packages = [
    "cargo-${rustc-host}",
    "rustc-${rustc-host}",
    "rustfmt-${rustc-host}",
    "rust-std-${rustc-host}",
]  
```

3. Run `criticalup run (--strict) cargo clippy` 

The compiler complains of having libraries compiled with an incompatible rustc version

```
error[E0514]: found crate `elliptic_curve` compiled by an incompatible version of rustc                                        
 --> crates/criticaltrust/src/keys/algorithms/ecdsa_p256_sha256_asn1_spki_der.rs:7:5                                           
  |                                                                                                                                                                                                                                                           
7 | use elliptic_curve::pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePrivateKey, EncodePublicKey};
  |     ^^^^^^^^^^^^^^                                                                                                         
  |                                                                                                                                                                                                                                                           
  = note: the following crate versions were found:                                                                                                                                                                                                            
          crate `elliptic_curve` compiled by rustc 1.88.0 (4a1d753a8 2025-09-29) (Ferrocene by Ferrous Systems): /home/emir/Github/ferrocene/public/criticalup/target/debug/deps/libelliptic_curve-a7d5321835367b5b.rmeta                                     
  = help: please recompile that crate using this compiler (rustc 1.93.1 (01f6ddf75 2026-02-11)) (consider running `cargo clean` first)  
```

How to test this PR
---------------------------

1. Follow the mentioned replication steps
2. With this PR changes the following warning is expected:

>  WARN 'cargo-clippy' is not installed for this project, and may run from binaries outside the criticalup installation.
 To prevent this, please make sure that the correct package for 'cargo-clippy' is listed in the packages section of your 
project's criticalup.toml and run 'criticalup install' command again.

Note: In this example, if criticalup is linked as a rustup toolchain and used (is active), both a warning and an actual error will be returned.  The later is due to the `cargo-clippy` binary missing in the path