### PR TITLE
Bump use-ferrocene gh action hash reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Uses Ferrocene from shareable actions
-        uses: ferrous-systems/shared-github-actions/use-ferrocene@daf0e64d44739e26443a8751183df1e9a2c91eb2
+        uses: ferrous-systems/shared-github-actions/use-ferrocene@0ba9001deaafb04888b9646b481064ae54fb47b4
         with:
           token: ${{ secrets.CRITICALUP_TOKEN }}
           uninstall-rustup: false
           toolchain-link: true
+          cache-toolchain: false
 
       - name: Install zig
         if: ${{ runner.os == 'Linux' }}
@@ -73,16 +74,16 @@ jobs:
 
       - name: Install cargo-zigbuild
         if: ${{ runner.os == 'Linux' }}
-        run: cargo binstall cargo-zigbuild
+        run: cargo --version && cargo binstall cargo-zigbuild
 
       - name: Cache Rust dependencies
         uses: ferrous-systems/shared-github-actions/cache-rust@main
 
       - name: Check formatting
-        run: cargo fmt --all --check
+        run: cargo fmt --version && cargo fmt --all --check
 
       - name: Check Clippy warnings
-        run: cargo clippy --tests --locked -- -Dwarnings
+        run: cargo clippy --version && cargo clippy --tests --locked -- -Dwarnings
 
       - name: Prepare file to record snapshots used by insta
         run: echo "INSTA_SNAPSHOT_REFERENCES_FILE=$(mktemp)" >> "${GITHUB_ENV}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,11 +34,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Uses Ferrocene from shareable actions
-        uses: ferrous-systems/shared-github-actions/use-ferrocene@daf0e64d44739e26443a8751183df1e9a2c91eb2
+        uses: ferrous-systems/shared-github-actions/use-ferrocene@0ba9001deaafb04888b9646b481064ae54fb47b4
         with:
           token: ${{ secrets.CRITICALUP_TOKEN }}
           uninstall-rustup: false
           toolchain-link: true
+          cache-toolchain: false
 
       - name: Install WiX
         run: |


### PR DESCRIPTION
- Bumps and adds configuration flag for shared gh action dependency: we don't want to use the cache-toolchain functionality, we want to excercise the integration with the download server.
- This new version sets the `default toolchain to Ferrocene` 
- Print version of commands run (facilitates debugging toolchain version related problems)