### PR TITLE
Fix `Error` being `pub(crate)`

### DIFF
--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -11,7 +11,7 @@ use std::string::FromUtf8Error as Utf8Error;
 use tokio::task::JoinError;
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error(transparent)]
     Lib(#[from] LibError),
     #[error(transparent)]


### PR DESCRIPTION
Noticed a build failure that this fixes. `cargo build -p criticalup-cli`