### PR TITLE
fix: compilation with 1.96.1

### DIFF
--- a/crates/criticalup-cli/src/errors.rs
+++ b/crates/criticalup-cli/src/errors.rs
@@ -11,7 +11,7 @@ use std::string::FromUtf8Error as Utf8Error;
 use tokio::task::JoinError;
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error(transparent)]
     Lib(#[from] LibError),
     #[error(transparent)]

--- a/crates/criticalup-cli/src/lib.rs
+++ b/crates/criticalup-cli/src/lib.rs
@@ -3,7 +3,7 @@
 
 mod binary_proxies;
 mod cli;
-mod errors;
+pub mod errors;
 mod spawn;
 
 use crate::errors::Error;


### PR DESCRIPTION
Rust complain when compiling with `--package=criticalup` that the the `pub(crate)` `Error` type is exposed via the `pub` `CommandExecute` trait.